### PR TITLE
Added [DOMAIN] and [HOST] variables to Web Policy.

### DIFF
--- a/Languages/Resources.xml
+++ b/Languages/Resources.xml
@@ -20253,7 +20253,7 @@
   <Resource>
     <File>DesktopModules\SolidCP\App_LocalResources\SettingsWebPolicy.ascx.resx</File>
     <Key>lblFoldersDescription.Text</Key>
-    <DefaultValue>* All folders are relative to Space home&lt;br&gt;* [DOMAIN_NAME] variable is allowed</DefaultValue>
+    <DefaultValue>* All folders are relative to Space home&lt;br&gt;* Allowed variables are [DOMAIN_NAME], [HOST] and [DOMAIN]</DefaultValue>
   </Resource>
   <Resource>
     <File>DesktopModules\SolidCP\App_LocalResources\SettingsWebPolicy.ascx.resx</File>

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/WebServers/WebServerController.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/WebServers/WebServerController.cs
@@ -345,19 +345,19 @@ namespace SolidCP.EnterpriseServer
                     randDomainName += "_" + Utils.GetRandomString(DOMAIN_RANDOM_LENGTH);
 
                 // ROOT folder
-                site.ContentPath = GetWebFolder(packageId, WEBSITE_ROOT_FOLDER_PATTERN, randDomainName);
+                site.ContentPath = GetWebFolder(packageId, WEBSITE_ROOT_FOLDER_PATTERN, randDomainName, hostName, domainName);
                 if (!String.IsNullOrEmpty(webPolicy["WebRootFolder"]))
-                    site.ContentPath = GetWebFolder(packageId, webPolicy["WebRootFolder"], randDomainName);
+                    site.ContentPath = GetWebFolder(packageId, webPolicy["WebRootFolder"], randDomainName, hostName, domainName);
 
                 // LOGS folder
-                site.LogsPath = GetWebFolder(packageId, WEBSITE_LOGS_FOLDER_PATTERN, randDomainName);
+                site.LogsPath = GetWebFolder(packageId, WEBSITE_LOGS_FOLDER_PATTERN, randDomainName, hostName, domainName);
                 if (!String.IsNullOrEmpty(webPolicy["WebLogsFolder"]))
-                    site.LogsPath = GetWebFolder(packageId, webPolicy["WebLogsFolder"], randDomainName);
+                    site.LogsPath = GetWebFolder(packageId, webPolicy["WebLogsFolder"], randDomainName, hostName, domainName);
 
                 // DATA folder
-                site.DataPath = GetWebFolder(packageId, WEBSITE_DATA_FOLDER_PATTERN, randDomainName);
+                site.DataPath = GetWebFolder(packageId, WEBSITE_DATA_FOLDER_PATTERN, randDomainName, hostName, domainName);
                 if (!String.IsNullOrEmpty(webPolicy["WebDataFolder"]))
-                    site.DataPath = GetWebFolder(packageId, webPolicy["WebDataFolder"], randDomainName);
+                    site.DataPath = GetWebFolder(packageId, webPolicy["WebDataFolder"], randDomainName, hostName, domainName);
 
                 // default documents
                 site.DefaultDocs = null; // inherit from service
@@ -1270,12 +1270,14 @@ namespace SolidCP.EnterpriseServer
             }
         }
 
-        private static string GetWebFolder(int packageId, string pattern, string domainName)
+        private static string GetWebFolder(int packageId, string pattern, string domainName, string hostName, string domain)
         {
             string path = Utils.ReplaceStringVariable(pattern, "domain_name", domainName);
+            path = Utils.ReplaceStringVariable(path, "host", hostName);
+            path = Utils.ReplaceStringVariable(path, "domain", domain);
             return FilesController.GetFullPackagePath(packageId, path);
         }
-
+        
         private static string GetFrontPageUsername(string domainName)
         {
             int maxLength = MAX_ACCOUNT_LENGTH - FRONTPAGE_ACCOUNT_SUFFIX.Length - 1;
@@ -4112,6 +4114,13 @@ Please ensure the space has been allocated {0} IP address as a dedicated one and
             UserSettings webPolicy = UserController.GetUserSettings(user.UserId, UserSettings.WEB_POLICY);
             string packageHome = FilesController.GetHomeFolder(packageId);
 
+            // need to extract hostName and domainName from itemName
+            // assumes the first segment is the host and the remaining segments are the domain
+            // so works for www.domain.com  or shop.domain.co.uk  but not domain.co.uk or domain.com 
+            string[] parts = Utils.ParseDelimitedString(itemName, '.');
+            string hostName = parts[0];
+            string domainName = String.Join(".", parts.Skip(1));
+
             // add random string to the domain if specified
             string randDomainName = itemName;
             if (!String.IsNullOrEmpty(webPolicy["AddRandomDomainString"])
@@ -4119,22 +4128,22 @@ Please ensure the space has been allocated {0} IP address as a dedicated one and
                 randDomainName += "_" + Utils.GetRandomString(DOMAIN_RANDOM_LENGTH);
 
             // ROOT folder
-            string contentPath = GetWebFolder(packageId, WEBSITE_ROOT_FOLDER_PATTERN, randDomainName);
+            string contentPath = GetWebFolder(packageId, WEBSITE_ROOT_FOLDER_PATTERN, randDomainName, hostName, domainName);
             if (!String.IsNullOrEmpty(webPolicy["WebRootFolder"]))
-                contentPath = GetWebFolder(packageId, webPolicy["WebRootFolder"], randDomainName);
+                contentPath = GetWebFolder(packageId, webPolicy["WebRootFolder"], randDomainName, hostName, domainName);
 
             // LOGS folder
-            string logsPath = GetWebFolder(packageId, WEBSITE_LOGS_FOLDER_PATTERN, randDomainName);
+            string logsPath = GetWebFolder(packageId, WEBSITE_LOGS_FOLDER_PATTERN, randDomainName, hostName, domainName);
             if (!String.IsNullOrEmpty(webPolicy["WebLogsFolder"]))
-                logsPath = GetWebFolder(packageId, webPolicy["WebLogsFolder"], randDomainName);
+                logsPath = GetWebFolder(packageId, webPolicy["WebLogsFolder"], randDomainName, hostName, domainName);
 
             // DATA folder
-            string dataPath = GetWebFolder(packageId, WEBSITE_DATA_FOLDER_PATTERN, randDomainName);
+            string dataPath = GetWebFolder(packageId, WEBSITE_DATA_FOLDER_PATTERN, randDomainName, hostName, domainName);
             if (!String.IsNullOrEmpty(webPolicy["WebDataFolder"]))
-                dataPath = GetWebFolder(packageId, webPolicy["WebDataFolder"], randDomainName);
+                dataPath = GetWebFolder(packageId, webPolicy["WebDataFolder"], randDomainName, hostName, domainName);
 
             // copy site files
-			try
+            try
 			{
 				os.CopyFile(site.ContentPath, contentPath);
 			}

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/SettingsWebPolicy.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/SettingsWebPolicy.ascx.resx
@@ -214,7 +214,7 @@
     <value>Default Documents:</value>
   </data>
   <data name="lblFoldersDescription.Text" xml:space="preserve">
-    <value>* All folders are relative to Space home&lt;br&gt;* [DOMAIN_NAME] variable is allowed</value>
+    <value>* All folders are relative to Space home&lt;br&gt;* Allowed variables are [DOMAIN_NAME], [HOST] and [DOMAIN]</value>
   </data>
   <data name="lblFrontPagePassword.Text" xml:space="preserve">
     <value>Password Policy:</value>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SettingsWebPolicy.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SettingsWebPolicy.ascx
@@ -313,7 +313,7 @@
         <tr>
             <td class="Normal"></td>
             <td class="Normal">
-                <asp:Label ID="lblFoldersDescription" runat="server" meta:resourcekey="lblFoldersDescription" Text="* All folders are relative to Space home<br/>* [DOMAIN_NAME] variable is allowed"></asp:Label>
+                <asp:Label ID="lblFoldersDescription" runat="server" meta:resourcekey="lblFoldersDescription" Text="* All folders are relative to Space home<br/>* Allowed variables are [DOMAIN_NAME], [HOST] and [DOMAIN]"></asp:Label>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
# Description

Enhancement to allow [DOMAIN] and [HOST] variables to be used when specifying web site folder paths in Web Policy Settings.

- Works when creating a new website.
- Works for importing sites that follow the pattern host.domain.tld or host.domain.sld.tld

- When importing, assumes the first part is the host name ("www") and the remainder is the domain ("domain.co.uk").  If there is no host part then it will treat the domain as the host which will be wrong. Short of maintaining a full list of all .sld.tld combinations, no way to make this 100% foolproof.

Fixes # N/A

# How Has This Been Tested?
-  Manually Tested
-  Built code to ensure it has no errors

# Checklist:
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
