### PR TITLE
[RDS] Remove Authenticated Users from collections GPO / [HyperV2012R2+] Move clustered VM to another host if not enough memory / [WebDavPortal] Subfolders

### DIFF
--- a/SolidCP/Database/update_db.sql
+++ b/SolidCP/Database/update_db.sql
@@ -14571,7 +14571,7 @@ SET @EndRow = @StartRow + @MaximumRows
 
 DECLARE @Folders TABLE
 (
-	ItemPosition int IDENTITY(0,1),
+	ItemPosition int IDENTITY(1,1),
 	Id int
 )
 INSERT INTO @Folders (Id)

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Client/EnterpriseStorageProxy.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Client/EnterpriseStorageProxy.cs
@@ -54,7 +54,9 @@ namespace SolidCP.EnterpriseServer {
         private System.Threading.SendOrPostCallback GetEnterpriseFolderWithExtraDataOperationCompleted;
         
         private System.Threading.SendOrPostCallback CreateEnterpriseFolderOperationCompleted;
-        
+
+        private System.Threading.SendOrPostCallback CreateEnterpriseSubFolderOperationCompleted;
+
         private System.Threading.SendOrPostCallback DeleteEnterpriseFolderOperationCompleted;
         
         private System.Threading.SendOrPostCallback GetEnterpriseFolderPermissionsOperationCompleted;
@@ -149,7 +151,10 @@ namespace SolidCP.EnterpriseServer {
         
         /// <remarks/>
         public event CreateEnterpriseFolderCompletedEventHandler CreateEnterpriseFolderCompleted;
-        
+
+        /// <remarks/>
+        public event CreateEnterpriseSubFolderCompletedEventHandler CreateEnterpriseSubFolderCompleted;
+
         /// <remarks/>
         public event DeleteEnterpriseFolderCompletedEventHandler DeleteEnterpriseFolderCompleted;
         
@@ -674,7 +679,59 @@ namespace SolidCP.EnterpriseServer {
                 this.CreateEnterpriseFolderCompleted(this, new CreateEnterpriseFolderCompletedEventArgs(invokeArgs.Results, invokeArgs.Error, invokeArgs.Cancelled, invokeArgs.UserState));
             }
         }
-        
+
+        /// <remarks/>
+        [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/enterpriseserver/CreateEnterpriseSubFolder", RequestNamespace = "http://smbsaas/solidcp/enterpriseserver", ResponseNamespace = "http://smbsaas/solidcp/enterpriseserver", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
+        public ResultObject CreateEnterpriseSubFolder(int itemId, string folderPath)
+        {
+            object[] results = this.Invoke("CreateEnterpriseSubFolder", new object[] {
+                        itemId,
+                        folderPath});
+            return ((ResultObject)(results[0]));
+        }
+
+        /// <remarks/>
+        public System.IAsyncResult BeginCreateEnterpriseSubFolder(int itemId, string folderPath, System.AsyncCallback callback, object asyncState)
+        {
+            return this.BeginInvoke("CreateEnterpriseSubFolder", new object[] {
+                        itemId,
+                        folderPath}, callback, asyncState);
+        }
+
+        /// <remarks/>
+        public ResultObject EndCreateEnterpriseSubFolder(System.IAsyncResult asyncResult)
+        {
+            object[] results = this.EndInvoke(asyncResult);
+            return ((ResultObject)(results[0]));
+        }
+
+        /// <remarks/>
+        public void CreateEnterpriseSubFolderAsync(int itemId, string folderPath)
+        {
+            this.CreateEnterpriseSubFolderAsync(itemId, folderPath, null);
+        }
+
+        /// <remarks/>
+        public void CreateEnterpriseSubFolderAsync(int itemId, string folderPath, object userState)
+        {
+            if ((this.CreateEnterpriseSubFolderOperationCompleted == null))
+            {
+                this.CreateEnterpriseSubFolderOperationCompleted = new System.Threading.SendOrPostCallback(this.OnCreateEnterpriseSubFolderOperationCompleted);
+            }
+            this.InvokeAsync("CreateEnterpriseSubFolder", new object[] {
+                        itemId,
+                        folderPath}, this.CreateEnterpriseSubFolderOperationCompleted, userState);
+        }
+
+        private void OnCreateEnterpriseSubFolderOperationCompleted(object arg)
+        {
+            if ((this.CreateEnterpriseSubFolderCompleted != null))
+            {
+                System.Web.Services.Protocols.InvokeCompletedEventArgs invokeArgs = ((System.Web.Services.Protocols.InvokeCompletedEventArgs)(arg));
+                this.CreateEnterpriseSubFolderCompleted(this, new CreateEnterpriseSubFolderCompletedEventArgs(invokeArgs.Results, invokeArgs.Error, invokeArgs.Cancelled, invokeArgs.UserState));
+            }
+        }
+
         /// <remarks/>
         [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/enterpriseserver/DeleteEnterpriseFolder", RequestNamespace="http://smbsaas/solidcp/enterpriseserver", ResponseNamespace="http://smbsaas/solidcp/enterpriseserver", Use=System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle=System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
         public ResultObject DeleteEnterpriseFolder(int itemId, string folderName) {
@@ -2300,7 +2357,37 @@ namespace SolidCP.EnterpriseServer {
             }
         }
     }
-    
+
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("wsdl", "2.0.50727.3038")]
+    public delegate void CreateEnterpriseSubFolderCompletedEventHandler(object sender, CreateEnterpriseSubFolderCompletedEventArgs e);
+
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("wsdl", "2.0.50727.3038")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    public partial class CreateEnterpriseSubFolderCompletedEventArgs : System.ComponentModel.AsyncCompletedEventArgs
+    {
+
+        private object[] results;
+
+        internal CreateEnterpriseSubFolderCompletedEventArgs(object[] results, System.Exception exception, bool cancelled, object userState) :
+                base(exception, cancelled, userState)
+        {
+            this.results = results;
+        }
+
+        /// <remarks/>
+        public ResultObject Result
+        {
+            get
+            {
+                this.RaiseExceptionIfNecessary();
+                return ((ResultObject)(this.results[0]));
+            }
+        }
+    }
+
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("wsdl", "2.0.50727.3038")]
     public delegate void DeleteEnterpriseFolderCompletedEventHandler(object sender, DeleteEnterpriseFolderCompletedEventArgs e);

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Packages/PackageController.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Packages/PackageController.cs
@@ -573,6 +573,7 @@ namespace SolidCP.EnterpriseServer
                                     ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPS, domain, "");
                                     ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPS2012, domain, "");
                                     ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPSForPC, domain, "");
+                                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.RDS, domain, "");
                                 }
                             }
 

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Servers/ServerController.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Servers/ServerController.cs
@@ -2348,26 +2348,8 @@ namespace SolidCP.EnterpriseServer
 			{
 				if (domain.ZoneItemId != 0)
 				{
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.Os, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.Dns, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.Ftp, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2000, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2005, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2008, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2012, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2014, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2016, domain, "");
-                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2017, domain, "");
-                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MsSql2019, domain, "");
-                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MySql4, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MySql5, domain, "");
-                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MySql8, domain, "");
-                    ServerController.AddServiceDNSRecords(packageId, ResourceGroups.MariaDB, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.Statistics, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPS, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPS2012, domain, "");
-					ServerController.AddServiceDNSRecords(packageId, ResourceGroups.VPSForPC, domain, "");
-				}
+                    AddAllServiceDNS(domain);
+                }
 
 				UpdateDomainWhoisData(domain);
 			}
@@ -2908,164 +2890,8 @@ namespace SolidCP.EnterpriseServer
 
 					domain = GetDomain(domainId);
 
-
-					PackageContext cntx = PackageController.GetPackageContext(domain.PackageId);
-					if (cntx != null)
-					{
-						// fill dictionaries
-						foreach (HostingPlanGroupInfo group in cntx.GroupsArray)
-						{
-							try
-							{
-								bool bFound = false;
-								switch (group.GroupName)
-								{
-									case ResourceGroups.Dns:
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Ftp, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2000, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2005, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2008, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2012, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2014, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2016, domain, "");
-                                        ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2017, domain, "");
-                                        ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2019, domain, "");
-                                        ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql4, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql5, domain, "");
-                                        ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql8, domain, "");
-                                        ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MariaDB, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Statistics, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPS, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPS2012, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPSForPC, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Dns, domain, "");
-										break;
-									case ResourceGroups.Os:
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Os, domain, "");
-										break;
-									case ResourceGroups.HostedOrganizations:
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.HostedOrganizations, domain, "");
-										ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.HostedCRM, domain, "");
-										break;
-									case ResourceGroups.Mail:
-										List<DomainInfo> myDomains = ServerController.GetMyDomains(domain.PackageId);
-										foreach (DomainInfo mailDomain in myDomains)
-										{
-											if ((mailDomain.MailDomainId != 0) && (domain.DomainName.ToLower() == mailDomain.DomainName.ToLower()))
-											{
-												bFound = true;
-												break;
-											}
-										}
-										if (bFound) ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Mail, domain, "");
-										break;
-									case ResourceGroups.Exchange:
-										List<Organization> orgs = OrganizationController.GetOrganizations(domain.PackageId, false);
-										foreach (Organization o in orgs)
-										{
-											List<OrganizationDomainName> names = OrganizationController.GetOrganizationDomains(o.Id);
-											foreach (OrganizationDomainName name in names)
-											{
-												if (domain.DomainName.ToLower() == name.DomainName.ToLower())
-												{
-													bFound = true;
-													break;
-												}
-											}
-											if (bFound) break;
-										}
-										if (bFound)
-										{
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Exchange, domain, "");
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.BlackBerry, domain, "");
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.OCS, domain, "");
-										}
-										break;
-									case ResourceGroups.Lync:
-										List<Organization> orgsLync = OrganizationController.GetOrganizations(domain.PackageId, false);
-										foreach (Organization o in orgsLync)
-										{
-											if ((o.DefaultDomain.ToLower() == domain.DomainName.ToLower()) &
-												(o.LyncTenantId != null))
-											{
-												bFound = true;
-												break;
-											}
-										}
-										if (bFound)
-										{
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Lync, domain, "");
-										}
-										break;
-									case ResourceGroups.SfB:
-										List<Organization> orgsSfB = OrganizationController.GetOrganizations(domain.PackageId, false);
-										foreach (Organization o in orgsSfB)
-										{
-											if ((o.DefaultDomain.ToLower() == domain.DomainName.ToLower()) &
-												(o.SfBTenantId != null))
-											{
-												bFound = true;
-												break;
-											}
-										}
-										if (bFound)
-										{
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.SfB, domain, "");
-										}
-										break;
-									case ResourceGroups.Web:
-										List<WebSite> sites = WebServerController.GetWebSites(domain.PackageId, false);
-										foreach (WebSite w in sites)
-										{
-											if ((w.SiteId.ToLower().Replace("." + domain.DomainName.ToLower(), "").IndexOf('.') == -1) ||
-												(w.SiteId.ToLower() == domain.DomainName.ToLower()))
-											{
-												WebServerController.AddWebSitePointer(w.Id,
-																						(w.SiteId.ToLower() == domain.DomainName.ToLower()) ? "" : w.SiteId.ToLower().Replace("." + domain.DomainName.ToLower(), ""),
-																						domain.DomainId, false, true, true);
-											}
-
-											List<DomainInfo> pointers = WebServerController.GetWebSitePointers(w.Id);
-											foreach (DomainInfo pointer in pointers)
-											{
-												if ((pointer.DomainName.ToLower().Replace("." + domain.DomainName.ToLower(), "").IndexOf('.') == -1) ||
-													(pointer.DomainName.ToLower() == domain.DomainName.ToLower()))
-												{
-													WebServerController.AddWebSitePointer(w.Id,
-																							(pointer.DomainName.ToLower() == domain.DomainName.ToLower()) ? "" : pointer.DomainName.ToLower().Replace("." + domain.DomainName.ToLower(), ""),
-																							domain.DomainId, false, true, true);
-												}
-											}
-										}
-
-										if (sites.Count == 1)
-										{
-											// load site item
-											IPAddressInfo ip = ServerController.GetIPAddress(sites[0].SiteIPAddressId);
-
-											string serviceIp = (ip != null) ? ip.ExternalIP : null;
-
-											if (string.IsNullOrEmpty(serviceIp))
-											{
-												StringDictionary settings = ServerController.GetServiceSettings(sites[0].ServiceId);
-												if (settings["PublicSharedIP"] != null)
-													serviceIp = settings["PublicSharedIP"].ToString();
-											}
-
-											ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Web, domain, serviceIp, true);
-										}
-
-										break;
-								}
-							}
-							catch (Exception ex)
-							{
-								TaskManager.WriteError(ex);
-							}
-						}
-					}
-
-				}
+                    AddAllServiceDNS(domain);
+                }
 
 				// add web site DNS records
 				int res = AddWebSiteZoneRecords("", domainId);
@@ -3083,6 +2909,168 @@ namespace SolidCP.EnterpriseServer
 				TaskManager.CompleteTask();
 			}
 		}
+
+        private static void AddAllServiceDNS(DomainInfo domain)
+        {
+            PackageContext cntx = PackageController.GetPackageContext(domain.PackageId);
+            if (cntx != null)
+            {
+                // fill dictionaries
+                foreach (HostingPlanGroupInfo group in cntx.GroupsArray)
+                {
+                    try
+                    {
+                        bool bFound = false;
+                        switch (group.GroupName)
+                        {
+                            case ResourceGroups.Dns:
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Ftp, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2000, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2005, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2008, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2012, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2014, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2016, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2017, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MsSql2019, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql4, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql5, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MySql8, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.MariaDB, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Statistics, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPS, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPS2012, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.VPSForPC, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Dns, domain, "");
+                                break;
+                            case ResourceGroups.Os:
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Os, domain, "");
+                                break;
+                            case ResourceGroups.RDS:
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.RDS, domain, "");
+                                break;
+                            case ResourceGroups.HostedOrganizations:
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.HostedOrganizations, domain, "");
+                                ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.HostedCRM, domain, "");
+                                break;
+                            case ResourceGroups.Mail:
+                                List<DomainInfo> myDomains = ServerController.GetMyDomains(domain.PackageId);
+                                foreach (DomainInfo mailDomain in myDomains)
+                                {
+                                    if ((mailDomain.MailDomainId != 0) && (domain.DomainName.ToLower() == mailDomain.DomainName.ToLower()))
+                                    {
+                                        bFound = true;
+                                        break;
+                                    }
+                                }
+                                if (bFound) ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Mail, domain, "");
+                                break;
+                            case ResourceGroups.Exchange:
+                                List<Organization> orgs = OrganizationController.GetOrganizations(domain.PackageId, false);
+                                foreach (Organization o in orgs)
+                                {
+                                    List<OrganizationDomainName> names = OrganizationController.GetOrganizationDomains(o.Id);
+                                    foreach (OrganizationDomainName name in names)
+                                    {
+                                        if (domain.DomainName.ToLower() == name.DomainName.ToLower())
+                                        {
+                                            bFound = true;
+                                            break;
+                                        }
+                                    }
+                                    if (bFound) break;
+                                }
+                                if (bFound)
+                                {
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Exchange, domain, "");
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.BlackBerry, domain, "");
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.OCS, domain, "");
+                                }
+                                break;
+                            case ResourceGroups.Lync:
+                                List<Organization> orgsLync = OrganizationController.GetOrganizations(domain.PackageId, false);
+                                foreach (Organization o in orgsLync)
+                                {
+                                    if ((o.DefaultDomain.ToLower() == domain.DomainName.ToLower()) &
+                                        (o.LyncTenantId != null))
+                                    {
+                                        bFound = true;
+                                        break;
+                                    }
+                                }
+                                if (bFound)
+                                {
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Lync, domain, "");
+                                }
+                                break;
+                            case ResourceGroups.SfB:
+                                List<Organization> orgsSfB = OrganizationController.GetOrganizations(domain.PackageId, false);
+                                foreach (Organization o in orgsSfB)
+                                {
+                                    if ((o.DefaultDomain.ToLower() == domain.DomainName.ToLower()) &
+                                        (o.SfBTenantId != null))
+                                    {
+                                        bFound = true;
+                                        break;
+                                    }
+                                }
+                                if (bFound)
+                                {
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.SfB, domain, "");
+                                }
+                                break;
+                            case ResourceGroups.Web:
+                                List<WebSite> sites = WebServerController.GetWebSites(domain.PackageId, false);
+                                foreach (WebSite w in sites)
+                                {
+                                    if ((w.SiteId.ToLower().Replace("." + domain.DomainName.ToLower(), "").IndexOf('.') == -1) ||
+                                        (w.SiteId.ToLower() == domain.DomainName.ToLower()))
+                                    {
+                                        WebServerController.AddWebSitePointer(w.Id,
+                                                                                (w.SiteId.ToLower() == domain.DomainName.ToLower()) ? "" : w.SiteId.ToLower().Replace("." + domain.DomainName.ToLower(), ""),
+                                                                                domain.DomainId, false, true, true);
+                                    }
+
+                                    List<DomainInfo> pointers = WebServerController.GetWebSitePointers(w.Id);
+                                    foreach (DomainInfo pointer in pointers)
+                                    {
+                                        if ((pointer.DomainName.ToLower().Replace("." + domain.DomainName.ToLower(), "").IndexOf('.') == -1) ||
+                                            (pointer.DomainName.ToLower() == domain.DomainName.ToLower()))
+                                        {
+                                            WebServerController.AddWebSitePointer(w.Id,
+                                                                                    (pointer.DomainName.ToLower() == domain.DomainName.ToLower()) ? "" : pointer.DomainName.ToLower().Replace("." + domain.DomainName.ToLower(), ""),
+                                                                                    domain.DomainId, false, true, true);
+                                        }
+                                    }
+                                }
+
+                                if (sites.Count == 1)
+                                {
+                                    // load site item
+                                    IPAddressInfo ip = ServerController.GetIPAddress(sites[0].SiteIPAddressId);
+
+                                    string serviceIp = (ip != null) ? ip.ExternalIP : null;
+
+                                    if (string.IsNullOrEmpty(serviceIp))
+                                    {
+                                        StringDictionary settings = ServerController.GetServiceSettings(sites[0].ServiceId);
+                                        if (settings["PublicSharedIP"] != null)
+                                            serviceIp = settings["PublicSharedIP"].ToString();
+                                    }
+
+                                    ServerController.AddServiceDNSRecords(domain.PackageId, ResourceGroups.Web, domain, serviceIp, true);
+                                }
+
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        TaskManager.WriteError(ex);
+                    }
+                }
+            }
+        }
 
 		private static int AddWebSiteZoneRecords(string hostName, int domainId)
 		{

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/GuacaHelper.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/GuacaHelper.cs
@@ -47,7 +47,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers
                 return "";
             }
 
-            cookiedata.security = "nla";
+            cookiedata.security = "vmconnect";
             cookiedata.protocol = "rdp";
             cookiedata.port = "2179";
             cookiedata.vmhostname = vm.Hostname;

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
@@ -1242,7 +1242,7 @@ namespace SolidCP.EnterpriseServer
                 try
                 {
                     // start virtual machine
-                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.Start);
+                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.Start, vm.ClusterName);
 
                     // check return
                     if (result.ReturnValue == ReturnCode.JobStarted)
@@ -2397,7 +2397,7 @@ namespace SolidCP.EnterpriseServer
                     else if (state == VirtualMachineRequestedState.Reset)
                     {
                         // reset machine
-                        JobResult result = vps.ChangeVirtualMachineState(machine.VirtualMachineId, VirtualMachineRequestedState.Reset);
+                        JobResult result = vps.ChangeVirtualMachineState(machine.VirtualMachineId, VirtualMachineRequestedState.Reset, machine.ClusterName);
 
                         if (result.Job.JobState == ConcreteJobState.Completed)
                         {
@@ -2429,7 +2429,7 @@ namespace SolidCP.EnterpriseServer
                         if (state == VirtualMachineRequestedState.Resume)
                             state = VirtualMachineRequestedState.Start;
 
-                        JobResult result = vps.ChangeVirtualMachineState(machine.VirtualMachineId, state);
+                        JobResult result = vps.ChangeVirtualMachineState(machine.VirtualMachineId, state, machine.ClusterName);
 
                         if (result.Job.JobState == ConcreteJobState.Completed)
                         {
@@ -2686,6 +2686,8 @@ namespace SolidCP.EnterpriseServer
                 // load service settings
                 StringDictionary settings = ServerController.GetServiceSettings(vm.ServiceId);
 
+                vm.ClusterName = (Utils.ParseBool(settings["UseFailoverCluster"], false)) ? settings["ClusterName"] : null;
+
                 #region setup external network
                 if (vm.ExternalNetworkEnabled
                     && String.IsNullOrEmpty(vm.ExternalNicMacAddress))
@@ -2755,7 +2757,7 @@ namespace SolidCP.EnterpriseServer
                         else
                         {
                             // turn off
-                            result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff);
+                            result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff, vm.ClusterName);
                             if (!JobCompleted(vs, result.Job))
                             {
                                 LogJobResult(res, result.Job);
@@ -2793,7 +2795,7 @@ namespace SolidCP.EnterpriseServer
                 if (wasStarted && !isSuccessChangedWihoutReboot)
                 {
                     TaskManager.Write(String.Format("Starting the server..."));
-                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.Start);
+                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.Start, vm.ClusterName);
                     if (!JobCompleted(vs, result.Job))
                     {
                         LogJobResult(res, result.Job);
@@ -3127,7 +3129,7 @@ namespace SolidCP.EnterpriseServer
                 // stop virtual machine
                 if (vps.State != VirtualMachineState.Off)
                 {
-                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff);
+                    result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff, vm.ClusterName);
                     if (!JobCompleted(vs, result.Job))
                     {
                         LogJobResult(res, result.Job);
@@ -4390,7 +4392,7 @@ namespace SolidCP.EnterpriseServer
                     if (vps.State != VirtualMachineState.Off)
                     {
                         TaskManager.Write("VPS_DELETE_TURN_OFF");
-                        result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff);
+                        result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff, vm.ClusterName);
                         // check result
                         if (result.ReturnValue != ReturnCode.JobStarted)
                         {
@@ -4590,7 +4592,7 @@ namespace SolidCP.EnterpriseServer
                     if (vps.State != VirtualMachineState.Off)
                     {
                         TaskManager.Write("VPS_DELETE_TURN_OFF");
-                        result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff);
+                        result = vs.ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff, vm.ClusterName);
 
                         // check result
                         if (result.ReturnValue != ReturnCode.JobStarted)

--- a/SolidCP/Sources/SolidCP.EnterpriseServer/esEnterpriseStorage.asmx.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer/esEnterpriseStorage.asmx.cs
@@ -122,6 +122,12 @@ namespace SolidCP.EnterpriseServer
         }
 
         [WebMethod]
+        public ResultObject CreateEnterpriseSubFolder(int itemId, string folderPath)
+        {
+            return EnterpriseStorageController.CreateSubFolder(itemId, folderPath);
+        }
+
+        [WebMethod]
         public ResultObject DeleteEnterpriseFolder(int itemId, string folderName)
         {
             return EnterpriseStorageController.DeleteFolder(itemId, folderName);

--- a/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/IVirtualizationServer2012.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/IVirtualizationServer2012.cs
@@ -45,7 +45,7 @@ namespace SolidCP.Providers.Virtualization
         byte[] GetVirtualMachineThumbnailImage(string vmId, ThumbnailSize size);
         VirtualMachine CreateVirtualMachine(VirtualMachine vm);
         VirtualMachine UpdateVirtualMachine(VirtualMachine vm);
-        JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState);
+        JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName);
         ReturnCode ShutDownVirtualMachine(string vmId, bool force, string reason);
         List<ConcreteJob> GetVirtualMachineJobs(string vmId);
         JobResult RenameVirtualMachine(string vmId, string name, string clusterName);

--- a/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/VirtualMachine.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/VirtualMachine.cs
@@ -178,5 +178,6 @@ namespace SolidCP.Providers.Virtualization
         public string CustomPrivateMask { get; set; }
         [Persistent]
         public string ClusterName { get; set; }
+        public bool IsClustered { get; set; }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.HostedSolution/OrganizationProvider.cs
+++ b/SolidCP/Sources/SolidCP.Providers.HostedSolution/OrganizationProvider.cs
@@ -441,14 +441,25 @@ namespace SolidCP.Providers.HostedSolution
             string msExchVersion = ActiveDirectoryUtils.GetADObjectStringProperty(entry, "msExchVersion");
             if (!string.IsNullOrEmpty(msExchVersion))
             {
-                filter =
-                string.Format(CultureInfo.InvariantCulture, "(&(objectClass=user)(!{0}=disabled))",
-                              ADAttributes.CustomAttribute2);
+                if (enabled)
+                {
+                    filter = string.Format(CultureInfo.InvariantCulture, "(&(objectClass=user)({0}=disabled))", ADAttributes.CustomAttribute2);
+                }
+                else
+                {
+                    filter = string.Format(CultureInfo.InvariantCulture, "(&(objectClass=user)(!{0}=disabled))", ADAttributes.CustomAttribute2);
+                }
             }
             else
             {
-                filter =
-                string.Format(CultureInfo.InvariantCulture, "(&(objectClass=user)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))");
+                if (enabled)
+                {
+                    filter = string.Format(CultureInfo.InvariantCulture, "(|(&(objectCategory=user)(memberOf={0}))(&(objectClass=computer)(userAccountControl:1.2.840.113556.1.4.803:=2)))", org.SecurityGroup);
+                }
+                else
+                {
+                    filter = string.Format(CultureInfo.InvariantCulture, "(&(objectClass=user)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))");
+                }
             }
 
             using (DirectorySearcher searcher = new DirectorySearcher(entry, filter))

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
@@ -1048,6 +1048,7 @@ namespace SolidCP.Providers.Virtualization
                 cmd.Parameters.Add("Name", vm.Name);
 
                 PowerShell.Execute(cmd, true);
+                System.Threading.Thread.Sleep(3500);
                 return JobHelper.CreateSuccessResult(ReturnCode.JobStarted);
             }
             catch (Exception ex)
@@ -1106,6 +1107,7 @@ namespace SolidCP.Providers.Virtualization
             {
                 var snapshot = GetSnapshot(snapshotId);
                 SnapshotHelper.Delete(PowerShell, snapshot, false);
+                System.Threading.Thread.Sleep(3000);
                 return JobHelper.CreateSuccessResult(ReturnCode.JobStarted);
             }
             catch (Exception ex)
@@ -1121,6 +1123,7 @@ namespace SolidCP.Providers.Virtualization
             {
                 var snapshot = GetSnapshot(snapshotId);
                 SnapshotHelper.Delete(PowerShell, snapshot, true);
+                System.Threading.Thread.Sleep(3000);
                 return JobHelper.CreateSuccessResult(ReturnCode.JobStarted);
             }
             catch (Exception ex)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
@@ -194,6 +194,7 @@ namespace SolidCP.Providers.Virtualization
                     vm.Heartbeat = VirtualMachineHelper.GetVMHeartBeatStatus(PowerShell, vm.Name);
                     vm.CreatedDate = result[0].GetProperty<DateTime>("CreationTime");
                     vm.ReplicationState = result[0].GetEnum<ReplicationState>("ReplicationState");
+                    vm.IsClustered = result[0].GetBool("IsClustered");
 
                     if (extendedInfo)
                     {
@@ -694,7 +695,7 @@ namespace SolidCP.Providers.Virtualization
             {
                 try
                 {
-                    jobResult = ChangeVirtualMachineState(vmId, newState);
+                    jobResult = ChangeVirtualMachineState(vmId, newState, null);
                     System.Threading.Thread.Sleep(1000);
                     loop = false;
                 }
@@ -718,7 +719,47 @@ namespace SolidCP.Providers.Virtualization
             return jobResult;
         }
 
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        private JobResult StartClusteredVM(string vmName, string clusterName)
+        {
+            try
+            {
+                Command cmd = new Command("Start-VM");
+                cmd.Parameters.Add("Name", vmName);
+                PowerShell.Execute(cmd, true, true);
+
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("0x8007000E")) // Not enough memory on Hyper-V host
+                {
+                    Command cmd = new Command("Move-ClusterVirtualMachineRole");
+                    cmd.Parameters.Add("Name", vmName);
+                    cmd.Parameters.Add("Cluster", clusterName);
+                    cmd.Parameters.Add("MigrationType", "Quick");
+                    Collection<PSObject> result = PowerShell.Execute(cmd, false, false);
+
+                    string hostName = null;
+                    if (result.Count > 0) hostName = result[0].GetProperty("OwnerNode").ToString();
+
+                    if (!String.IsNullOrEmpty(hostName))
+                    {
+                        cmd = new Command("Start-VM");
+                        cmd.Parameters.Add("Name", vmName);
+                        cmd.Parameters.Add("ComputerName", hostName);
+                        PowerShell.Execute(cmd, false, true);
+                    }
+                }
+                else
+                {
+                    HostedSolutionLog.LogError("ChangeVirtualMachineState", ex);
+                    throw;
+                }
+            }
+            HostedSolutionLog.LogEnd("ChangeVirtualMachineState");
+            return JobHelper.CreateSuccessResult(ReturnCode.JobStarted);
+        }
+
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             HostedSolutionLog.LogStart("ChangeVirtualMachineState");
             var jobResult = new JobResult();
@@ -739,6 +780,10 @@ namespace SolidCP.Providers.Virtualization
                 {
                     case VirtualMachineRequestedState.Start:
                         cmdTxt = "Start-VM";
+                        if (vm.IsClustered && !String.IsNullOrEmpty(clusterName))
+                        {
+                            return StartClusteredVM(vm.Name, clusterName);
+                        }
                         break;
                     case VirtualMachineRequestedState.Pause:
                         cmdTxt = "Suspend-VM";
@@ -766,7 +811,7 @@ namespace SolidCP.Providers.Virtualization
                 }
 
                 Command cmd = new Command(cmdTxt);
-
+                
                 cmd.Parameters.Add("Name", vm.Name);
                 //cmd.Parameters.Add("AsJob");
                 paramList.ForEach(p => cmd.Parameters.Add(p));
@@ -784,7 +829,7 @@ namespace SolidCP.Providers.Virtualization
                         case VirtualMachineRequestedState.Start: //sometimes we can get an error here, but it in 90% does not mean anything.
                             vm = GetVirtualMachine(vmId);
                             if (vm.Heartbeat != OperationalStatus.Ok || vm.State != VirtualMachineState.Running)
-                                ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.Reset);
+                                ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.Reset, clusterName);
                             cmdTxt = "";
                             break;
                         case VirtualMachineRequestedState.ShutDown: //get problem with Shutdown = turnoff
@@ -808,7 +853,7 @@ namespace SolidCP.Providers.Virtualization
                         PowerShell.Execute(cmd, true, true);
 
                         if (startVM)
-                            ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.Start);
+                            ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.Start, clusterName);
                     }                    
                 }
                 
@@ -833,7 +878,7 @@ namespace SolidCP.Providers.Virtualization
             if (isServerStatusOK)
                 VirtualMachineHelper.Stop(PowerShell, vm.Name, force, ServerNameSettings);
             else
-                ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.TurnOff);
+                ChangeVirtualMachineState(vmId, VirtualMachineRequestedState.TurnOff, null);
 
             return ReturnCode.OK;
         }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-vmm/HyperVvmm.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-vmm/HyperVvmm.cs
@@ -457,7 +457,7 @@ namespace SolidCP.Providers.Virtualization
             return false;
         }
 
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             HostedSolutionLog.LogStart("ChangeVirtualMachineState");
             var jobResult = new JobResult();
@@ -1531,7 +1531,7 @@ namespace SolidCP.Providers.Virtualization
                     if (vps.State == VirtualMachineState.Paused)
                         state = VirtualMachineRequestedState.Resume;
 
-                    result = ChangeVirtualMachineState(vm.VirtualMachineId, state);
+                    result = ChangeVirtualMachineState(vm.VirtualMachineId, state, null);
 
                     // check result
                     if (result.ReturnValue != ReturnCode.JobStarted)
@@ -1566,7 +1566,7 @@ namespace SolidCP.Providers.Virtualization
 
                     // turn off
                     VirtualMachineRequestedState state = VirtualMachineRequestedState.TurnOff;
-                    result = ChangeVirtualMachineState(vm.VirtualMachineId, state);
+                    result = ChangeVirtualMachineState(vm.VirtualMachineId, state, null);
 
                     // check result
                     if (result.ReturnValue != ReturnCode.JobStarted)
@@ -1611,7 +1611,7 @@ namespace SolidCP.Providers.Virtualization
                 #region Turn off (if required)
                 if (vps.State != VirtualMachineState.Off)
                 {
-                    result = ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff);
+                    result = ChangeVirtualMachineState(vm.VirtualMachineId, VirtualMachineRequestedState.TurnOff, null);
                     // check result
                     if (result.ReturnValue != ReturnCode.JobStarted)
                     {

--- a/SolidCP/Sources/SolidCP.Server.Client/VirtualizationServerProxy2012.cs
+++ b/SolidCP/Sources/SolidCP.Server.Client/VirtualizationServerProxy2012.cs
@@ -683,20 +683,22 @@ namespace SolidCP.Providers.Virtualization2012
         /// <remarks/>
         [System.Web.Services.Protocols.SoapHeaderAttribute("ServiceProviderSettingsSoapHeaderValue")]
         [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/server/ChangeVirtualMachineState", RequestNamespace = "http://smbsaas/solidcp/server/", ResponseNamespace = "http://smbsaas/solidcp/server/", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             object[] results = this.Invoke("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState});
+                        newState,
+                        clusterName});
             return ((JobResult)(results[0]));
         }
 
         /// <remarks/>
-        public System.IAsyncResult BeginChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, System.AsyncCallback callback, object asyncState)
+        public System.IAsyncResult BeginChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName, System.AsyncCallback callback, object asyncState)
         {
             return this.BeginInvoke("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState}, callback, asyncState);
+                        newState,
+                        clusterName}, callback, asyncState);
         }
 
         /// <remarks/>
@@ -707,13 +709,13 @@ namespace SolidCP.Providers.Virtualization2012
         }
 
         /// <remarks/>
-        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState)
+        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
-            this.ChangeVirtualMachineStateAsync(vmId, newState, null);
+            this.ChangeVirtualMachineStateAsync(vmId, newState, clusterName, null);
         }
 
         /// <remarks/>
-        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, object userState)
+        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, string clusterName, object userState)
         {
             if ((this.ChangeVirtualMachineStateOperationCompleted == null))
             {
@@ -721,7 +723,8 @@ namespace SolidCP.Providers.Virtualization2012
             }
             this.InvokeAsync("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState}, this.ChangeVirtualMachineStateOperationCompleted, userState);
+                        newState,
+                        clusterName}, this.ChangeVirtualMachineStateOperationCompleted, userState);
         }
 
         private void OnChangeVirtualMachineStateOperationCompleted(object arg)

--- a/SolidCP/Sources/SolidCP.Server.Client/VirtualizationServerProxy2016.cs
+++ b/SolidCP/Sources/SolidCP.Server.Client/VirtualizationServerProxy2016.cs
@@ -650,20 +650,22 @@ namespace SolidCP.Providers.Virtualization2016
         /// <remarks/>
         [System.Web.Services.Protocols.SoapHeaderAttribute("ServiceProviderSettingsSoapHeaderValue")]
         [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/server/ChangeVirtualMachineState", RequestNamespace = "http://smbsaas/solidcp/server/", ResponseNamespace = "http://smbsaas/solidcp/server/", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             object[] results = this.Invoke("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState});
+                        newState,
+                        clusterName});
             return ((JobResult)(results[0]));
         }
 
         /// <remarks/>
-        public System.IAsyncResult BeginChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, System.AsyncCallback callback, object asyncState)
+        public System.IAsyncResult BeginChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName, System.AsyncCallback callback, object asyncState)
         {
             return this.BeginInvoke("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState}, callback, asyncState);
+                        newState,
+                        clusterName}, callback, asyncState);
         }
 
         /// <remarks/>
@@ -674,13 +676,13 @@ namespace SolidCP.Providers.Virtualization2016
         }
 
         /// <remarks/>
-        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState)
+        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
-            this.ChangeVirtualMachineStateAsync(vmId, newState, null);
+            this.ChangeVirtualMachineStateAsync(vmId, newState, clusterName, null);
         }
 
         /// <remarks/>
-        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, object userState)
+        public void ChangeVirtualMachineStateAsync(string vmId, VirtualMachineRequestedState newState, string clusterName, object userState)
         {
             if ((this.ChangeVirtualMachineStateOperationCompleted == null))
             {
@@ -688,7 +690,8 @@ namespace SolidCP.Providers.Virtualization2016
             }
             this.InvokeAsync("ChangeVirtualMachineState", new object[] {
                         vmId,
-                        newState}, this.ChangeVirtualMachineStateOperationCompleted, userState);
+                        newState,
+                        clusterName}, this.ChangeVirtualMachineStateOperationCompleted, userState);
         }
 
         private void OnChangeVirtualMachineStateOperationCompleted(object arg)

--- a/SolidCP/Sources/SolidCP.Server.asp2.0/VirtualizationServer2012.asmx.cs
+++ b/SolidCP/Sources/SolidCP.Server.asp2.0/VirtualizationServer2012.asmx.cs
@@ -165,12 +165,12 @@ namespace SolidCP.Server
         }
 
         [WebMethod, SoapHeader("settings")]
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             try
             {
                 Log.WriteStart("'{0}' ChangeVirtualMachineState", ProviderSettings.ProviderName);
-                JobResult result = VirtualizationProvider.ChangeVirtualMachineState(vmId, newState);
+                JobResult result = VirtualizationProvider.ChangeVirtualMachineState(vmId, newState, clusterName);
                 Log.WriteEnd("'{0}' ChangeVirtualMachineState", ProviderSettings.ProviderName);
                 return result;
             }

--- a/SolidCP/Sources/SolidCP.Server/VirtualizationServer2012.asmx.cs
+++ b/SolidCP/Sources/SolidCP.Server/VirtualizationServer2012.asmx.cs
@@ -165,12 +165,12 @@ namespace SolidCP.Server
         }
 
         [WebMethod, SoapHeader("settings")]
-        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState)
+        public JobResult ChangeVirtualMachineState(string vmId, VirtualMachineRequestedState newState, string clusterName)
         {
             try
             {
                 Log.WriteStart("'{0}' ChangeVirtualMachineState", ProviderSettings.ProviderName);
-                JobResult result = VirtualizationProvider.ChangeVirtualMachineState(vmId, newState);
+                JobResult result = VirtualizationProvider.ChangeVirtualMachineState(vmId, newState, clusterName);
                 Log.WriteEnd("'{0}' ChangeVirtualMachineState", ProviderSettings.ProviderName);
                 return result;
             }

--- a/SolidCP/Sources/SolidCP.WebDav.Core/IFolder.cs
+++ b/SolidCP/Sources/SolidCP.WebDav.Core/IFolder.cs
@@ -148,12 +148,19 @@ namespace SolidCP.WebDav.Core
             /// <returns>Resource corresponding to requested name.</returns>
             public IResource GetResource(string name)
             {
-                IHierarchyItem item =
-                    _children.Single(i => i.DisplayName.ToLowerInvariant().Trim('/') == name.ToLowerInvariant().Trim('/'));
-                var resource = new WebDavResource();
-                resource.SetCredentials(_credentials);
-                resource.SetHierarchyItem(item);
-                return resource;
+                try
+                {
+                    IHierarchyItem item =
+                        _children.Single(i => i.DisplayName.ToLowerInvariant().Trim('/') == name.ToLowerInvariant().Trim('/'));
+                    var resource = new WebDavResource();
+                    resource.SetCredentials(_credentials);
+                    resource.SetHierarchyItem(item);
+                    return resource;
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
             }
 
             /// <summary>

--- a/SolidCP/Sources/SolidCP.WebDav.Core/Interfaces/Managers/IWebDavManager.cs
+++ b/SolidCP/Sources/SolidCP.WebDav.Core/Interfaces/Managers/IWebDavManager.cs
@@ -17,7 +17,7 @@ namespace SolidCP.WebDav.Core.Interfaces.Managers
         IEnumerable<IHierarchyItem> SearchFiles(int itemId, string pathPart, string searchValue, string uesrPrincipalName, bool recursive);
         IResource GetResource(string path);
         string GetFileUrl(string path);
-        void DeleteResource(string path);
+        void DeleteResource(string path, bool deleteNonEmptyFolder);
         void LockFile(string path);
         string GetFileFolderPath(string path);
     }

--- a/SolidCP/Sources/SolidCP.WebDav.Core/Managers/WebDavManager.cs
+++ b/SolidCP/Sources/SolidCP.WebDav.Core/Managers/WebDavManager.cs
@@ -202,7 +202,7 @@ namespace SolidCP.WebDav.Core.Managers
             resource.Lock();
         }
 
-        public void DeleteResource(string path)
+        public void DeleteResource(string path, bool deleteNonEmptyFolder)
         {
             path = RemoveLeadingFromPath(path, "office365");
             path = RemoveLeadingFromPath(path, "view");
@@ -217,9 +217,11 @@ namespace SolidCP.WebDav.Core.Managers
 
             IResource resource = _currentFolder.GetResource(resourceName);
 
-            if (resource.ItemType == ItemType.Folder && GetFoldersItemsCount(path) > 0)
+            if (resource == null) return;
+
+            if (resource.ItemType == ItemType.Folder && GetFoldersItemsCount(path) > 0 && !deleteNonEmptyFolder)
             {
-                throw new WebDavException(string.Format(WebDavResources.FolderIsNotEmptyFormat, resource.DisplayName));
+                throw new WebDavException(string.Format(WebDavResources.FolderIsNotEmptyFormat, resourceName), new Exception("NON_EMPTY_FOLDER"));
             }
 
             resource.Delete();

--- a/SolidCP/Sources/SolidCP.WebDavPortal/App_Start/RouteConfig.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/App_Start/RouteConfig.cs
@@ -109,6 +109,12 @@ namespace SolidCP.WebDavPortal
                 );
 
             routes.MapRoute(
+                name: FileSystemRouteNames.NewFolder,
+                url: "storage/new-folder/{org}/{*pathPart}",
+                defaults: new { controller = "FileSystem", action = "NewFolder" }
+                );
+
+            routes.MapRoute(
                     name: FileSystemRouteNames.SearchFiles,
                     url: "storage/search/{org}/{*pathPart}",
                     defaults: new { controller = "FileSystem", action = "SearchFiles", pathPart = UrlParameter.Optional }

--- a/SolidCP/Sources/SolidCP.WebDavPortal/App_Start/Routes/FileSystemRouteNames.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/App_Start/Routes/FileSystemRouteNames.cs
@@ -20,6 +20,7 @@ namespace SolidCP.WebDavPortal.UI.Routes
         public const string ShowAdditionalContent = "ShowAdditionalContentRoute";
 
         public const string UploadFile = "UplaodFIleRoute";
+        public const string NewFolder = "NewFolderRoute";
 
         public const string DeleteFiles = "DeleteFilesRoute";
 

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Content/Site.css
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Content/Site.css
@@ -383,6 +383,10 @@ tr.selected-file {
     max-width: 100%;
 }
 
+#foldernameForm input {
+    max-width: 100%;
+}
+
 /* Theme Mods */
 
 input,div{border-radius:0px!important;}

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
@@ -315,6 +315,15 @@ namespace SolidCP.WebDavPortal.Controllers
         public ActionResult NewFolder(string org, string pathPart)
         {
             string folderPath = pathPart + "/" + Request["foldername"];
+            var permissions = _webDavAuthorizationService.GetPermissions(ScpContext.User, pathPart);
+            if (!permissions.HasFlag(WebDavPermissions.Write))
+            {
+                var model = new ErrorModel
+                {
+                    Message = "Permission denied"
+                };
+                return Json(model);
+            }
             SCP.Services.EnterpriseStorage.CreateEnterpriseSubFolder(ScpContext.User.ItemId, folderPath);
             return new RedirectToRouteResult(FileSystemRouteNames.ShowContentPath, null);
         }

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
@@ -271,7 +271,7 @@ namespace SolidCP.WebDavPortal.Controllers
         }
 
         [HttpPost]
-        public JsonResult DeleteFiles(IEnumerable<string> filePathes = null)
+        public JsonResult DeleteFiles(IEnumerable<string> filePathes = null, bool deleteNonEmptyFolder = false)
         {
             var model = new DeleteFilesModel();
 
@@ -286,13 +286,20 @@ namespace SolidCP.WebDavPortal.Controllers
             {
                 try
                 {
-                    _webdavManager.DeleteResource(Server.UrlDecode(file));
+                    _webdavManager.DeleteResource(Server.UrlDecode(file), deleteNonEmptyFolder);
 
                     model.DeletedFiles.Add(file);
                 }
                 catch (WebDavException exception)
                 {
-                    model.AddMessage(MessageType.Error, exception.Message);
+                    if (exception.InnerException != null && !String.IsNullOrEmpty(exception.InnerException.Message))
+                    {
+                        model.AddMessage(MessageType.Error, exception.InnerException.Message);
+                    }
+                    else
+                    {
+                        model.AddMessage(MessageType.Error, exception.Message);
+                    }
                 }
             }
 

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Controllers/FileSystemController.cs
@@ -304,6 +304,14 @@ namespace SolidCP.WebDavPortal.Controllers
             return Json(model);
         }
 
+        [HttpPost]
+        public ActionResult NewFolder(string org, string pathPart)
+        {
+            string folderPath = pathPart + "/" + Request["foldername"];
+            SCP.Services.EnterpriseStorage.CreateEnterpriseSubFolder(ScpContext.User.ItemId, folderPath);
+            return new RedirectToRouteResult(FileSystemRouteNames.ShowContentPath, null);
+        }
+
         public ActionResult NewWebDavItem(string org, string pathPart)
         {
             var permissions = _webDavAuthorizationService.GetPermissions(ScpContext.User, pathPart);

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.Designer.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.Designer.cs
@@ -241,11 +241,29 @@ namespace SolidCP.WebDavPortal.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete All.
+        /// </summary>
+        public static string DeleteAll {
+            get {
+                return ResourceManager.GetString("DeleteAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete File?.
         /// </summary>
         public static string DeleteFileQuestion {
             get {
                 return ResourceManager.GetString("DeleteFileQuestion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This folder is not empty. Delete anyway?.
+        /// </summary>
+        public static string DeleteFolderAnyway {
+            get {
+                return ResourceManager.GetString("DeleteFolderAnyway", resourceCulture);
             }
         }
         
@@ -912,6 +930,15 @@ namespace SolidCP.WebDavPortal.Resources {
         public static string TerabyteShort {
             get {
                 return ResourceManager.GetString("TerabyteShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This folder is not empty.
+        /// </summary>
+        public static string ThisFolderNotEmpty {
+            get {
+                return ResourceManager.GetString("ThisFolderNotEmpty", resourceCulture);
             }
         }
         

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.Designer.cs
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.Designer.cs
@@ -19,7 +19,7 @@ namespace SolidCP.WebDavPortal.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class UI {
@@ -295,6 +295,15 @@ namespace SolidCP.WebDavPortal.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please enter folder name.
+        /// </summary>
+        public static string EnterFolderName {
+            get {
+                return ResourceManager.GetString("EnterFolderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
         public static string Error {
@@ -372,6 +381,15 @@ namespace SolidCP.WebDavPortal.Resources {
         public static string FirstName {
             get {
                 return ResourceManager.GetString("FirstName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder Name.
+        /// </summary>
+        public static string FolderName {
+            get {
+                return ResourceManager.GetString("FolderName", resourceCulture);
             }
         }
         
@@ -543,6 +561,15 @@ namespace SolidCP.WebDavPortal.Resources {
         public static string Name {
             get {
                 return ResourceManager.GetString("Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Folder.
+        /// </summary>
+        public static string NewFolder {
+            get {
+                return ResourceManager.GetString("NewFolder", resourceCulture);
             }
         }
         

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.resx
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.resx
@@ -420,4 +420,13 @@
   <data name="SendPincodeTo" xml:space="preserve">
     <value>When you click the send button below, a Password Reset PIN will be sent to your Cell Phone or Email Address.</value>
   </data>
+  <data name="EnterFolderName" xml:space="preserve">
+    <value>Please enter folder name</value>
+  </data>
+  <data name="FolderName" xml:space="preserve">
+    <value>Folder Name</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>New Folder</value>
+  </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.resx
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Resources/UI.resx
@@ -429,4 +429,13 @@
   <data name="NewFolder" xml:space="preserve">
     <value>New Folder</value>
   </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Delete All</value>
+  </data>
+  <data name="DeleteFolderAnyway" xml:space="preserve">
+    <value>This folder is not empty. Delete anyway?</value>
+  </data>
+  <data name="ThisFolderNotEmpty" xml:space="preserve">
+    <value>This folder is not empty</value>
+  </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Scripts/appScripts/SCP-webdav.js
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Scripts/appScripts/SCP-webdav.js
@@ -49,6 +49,15 @@ $(document).on('click', '.file-deletion #delete-button', function (e) {
     scp.dialogs.showConfirmDialog(title, content, buttonText, scp.fileBrowser.deleteSelectedItems, dialogId);
 });
 
+$(document).on('click', '.file-deletion #delete-all-button', function (e) {
+    var dialogId = $(this).data('target');
+    var buttonText = $(this).data('target-positive-button-text');
+    var content = $(this).data('target-content');
+    var title = $(this).data('target-title-text');
+    
+    scp.dialogs.showConfirmDialog(title, content, buttonText, scp.fileBrowser.deleteNonEmptyFolder, dialogId);
+});
+
 
 $(document).click(function (event) {
     if (!$(event.target).closest('.element-container, .prevent-deselect').length) {

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/ShowContent.cshtml
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/ShowContent.cshtml
@@ -18,23 +18,23 @@
 }
 else
 {
-   @Html.Partial("_ShowContentTopMenu", Model)
-    
-   @Html.Action("ContentList", "FileSystem", new { model = Model });
+    @Html.Partial("_ShowContentTopMenu", Model)
+
+    @Html.Action("ContentList", "FileSystem", new { model = Model });
 }
 
 
 @section scripts{
-    
+
     <script>
-        scp.fileBrowser.setSettings({ 
-            deletionUrl: "@Url.RouteUrl(FileSystemRouteNames.DeleteFiles)", 
+        scp.fileBrowser.setSettings({
+            deletionUrl: "@Url.RouteUrl(FileSystemRouteNames.DeleteFiles)",
             fileExistUrl: "@Url.RouteUrl(FileSystemRouteNames.ItemExist)",
             textItemExist: "@UI.ItemExist." });
     </script>
 
     @Scripts.Render("~/bundles/appScripts-webdav")
-    
+
     @if (Model.UserSettings.WebDavViewType == FolderViewTypes.BigIcons)
     {
         @Scripts.Render("~/bundles/bigIconsScripts")
@@ -82,6 +82,30 @@ else
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">@UI.Cancel</button>
                     <a href="@Url.RouteUrl(FileSystemRouteNames.NewWebDavItem)" data-href="@Url.RouteUrl(FileSystemRouteNames.NewWebDavItem)" id="create-button" class="btn btn-success danger">@UI.Create</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="newFolderDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-process-dialog-title" data-backdrop="static" data-keyboard="false" aria-hidden="true" style="display: none;">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                    <h4 class="modal-title" id="create-dalog-label" data-title="@UI.Create">@UI.Create</h4>
+                </div>
+
+                <div class="modal-body">
+                    <form id="foldernameForm" method="post" action="@Url.RouteUrl(FileSystemRouteNames.NewFolder)">
+                        <div class="form-group has-feedback">
+                            <label for="foldername">@UI.FolderName</label>
+                            <input type="text" class="form-control" id="foldername" name="foldername" autofocus required placeholder="@UI.EnterFolderName">
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">@UI.Cancel</button>
+                            <button type="submit" class="btn btn-success danger">@UI.Create</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/_ShowContentTopMenu.cshtml
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/_ShowContentTopMenu.cshtml
@@ -10,7 +10,7 @@
     @if (Model != null)
     {
         string header = ScpContext.User.OrganizationId;
-        string[] elements = string.IsNullOrEmpty(Model.UrlSuffix)? new string[0]: Model.UrlSuffix.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
+        string[] elements = string.IsNullOrEmpty(Model.UrlSuffix) ? new string[0] : Model.UrlSuffix.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
 
         <div class="breadcrumb-scp">
             @if (String.IsNullOrEmpty(Model.SearchValue))
@@ -59,19 +59,19 @@
                    data-target-content="@UI.DialogsContentConfrimFileDeletion">@UI.Delete</a>
             </div>
             if (Model.Permissions.HasFlag(WebDavPermissions.OwaEdit))
-             {
-                 <div class="dropdown create-new-item navbar-left">
-                     <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-expanded="true">
-                         @UI.Create
-                         <span class="caret"></span>
-                     </button>
-                     <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
-                         <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".docx" data-target="_blank">@UI.WordDocument</a></li>
-                         <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".xlsx" data-target="_blank">@UI.ExcelWorkbook</a></li>
-                         <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".pptx" data-target="_blank">@UI.PowerPointPresentation</a></li>
-                     </ul>
-                 </div>
-             }
+            {
+                <div class="dropdown create-new-item navbar-left">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-expanded="true">
+                        @UI.Create
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".docx" data-target="_blank">@UI.WordDocument</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".xlsx" data-target="_blank">@UI.ExcelWorkbook</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#" data-extension=".pptx" data-target="_blank">@UI.PowerPointPresentation</a></li>
+                    </ul>
+                </div>
+            }
         }
 
         <div class="file-upload navbar-right">
@@ -87,8 +87,19 @@
 
             @if (Model.Permissions.HasFlag(WebDavPermissions.Write))
             {
+                <a id="new-folder-button" class="btn btn-success btn-sm active" href="#" role="button" onclick="showNewFolderDialog('@UI.NewFolder');">@UI.NewFolder</a>
                 <a id="upload-button" class="btn btn-success btn-sm active" href="@Url.RouteUrl(FileSystemRouteNames.UploadFile)" role="button">@UI.FileUpload</a>
             }
         </div>
     </div>
+
+    <script>
+        function showNewFolderDialog(title) {
+            var createNewFolderDialogId = "#newFolderDialog";
+            var createNewFolderTitleId = '#create-dalog-label';
+            $(createNewFolderDialogId + " input").val("");
+            $(createNewFolderTitleId).text($(createNewFolderTitleId).data('title') + " " + title);
+            $(createNewFolderDialogId).modal();
+        }
+    </script>
 }

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/_ShowContentTopMenu.cshtml
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Views/FileSystem/_ShowContentTopMenu.cshtml
@@ -58,6 +58,13 @@
                    data-target-title-text="@UI.DeleteFileQuestion"
                    data-target-content="@UI.DialogsContentConfrimFileDeletion">@UI.Delete</a>
             </div>
+            <div class="file-deletion hidden">
+                <a id="delete-all-button" class="hidden" role="button"
+                   data-target="#confirm-dialog-2"
+                   data-target-positive-button-text="@UI.DeleteAll"
+                   data-target-title-text="@UI.ThisFolderNotEmpty"
+                   data-target-content="@UI.DeleteFolderAnyway">@UI.Delete</a>
+            </div>
             if (Model.Permissions.HasFlag(WebDavPermissions.OwaEdit))
             {
                 <div class="dropdown create-new-item navbar-left">

--- a/SolidCP/Sources/SolidCP.WebDavPortal/Views/Shared/_ConfirmDialog.cshtml
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Views/Shared/_ConfirmDialog.cshtml
@@ -11,9 +11,29 @@
             <div class="modal-body">
                 
             </div>
-
+            
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">@UI.Cancel</button>
+                <a href="#" class="btn btn-danger danger  positive-button" data-dismiss="modal">@UI.Yes</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="confirm-dialog-2" tabindex="-1" role="dialog" aria-labelledby="confirm-dalog-label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                <h4 class="modal-title" id="confirm-dalog-label">@UI.Confirm</h4>
+            </div>
+
+            <div class="modal-body">
+
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal" onclick="scp.fileBrowser.refreshDeletionBlock();scp.fileBrowser.refreshDataTable(scp.fileBrowser.itemsTable);">@UI.Cancel</button>
                 <a href="#" class="btn btn-danger danger  positive-button" data-dismiss="modal">@UI.Yes</a>
             </div>
         </div>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/EnterpriseStorageFolders.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/EnterpriseStorageFolders.ascx
@@ -65,7 +65,7 @@
                 <asp:HiddenField ID="hdnFolderName" runat="server" Value='<%# Eval("Name") %>' />
             </ItemTemplate>
         </asp:TemplateField>
-        <asp:TemplateField HeaderText="gvFolderName" SortExpression="Name">
+        <asp:TemplateField HeaderText="gvFolderName" SortExpression="FolderName">
             <ItemStyle Width="20%"></ItemStyle>
             <ItemTemplate>
                 <asp:hyperlink id="lnkFolderName" runat="server" NavigateUrl='<%# GetFolderEditUrl(Eval("Name").ToString()) %>'>
@@ -73,13 +73,13 @@
                 </asp:hyperlink>
             </ItemTemplate>
         </asp:TemplateField>
-        <asp:TemplateField HeaderText="gvFolderQuota" SortExpression="FRSMQuotaGB">
+        <asp:TemplateField HeaderText="gvFolderQuota" SortExpression="FolderQuota">
             <ItemStyle Width="15%"></ItemStyle>
             <ItemTemplate>
                 <asp:Literal id="litFolderQuota" runat="server" Text='<%# ConvertMBytesToGB(Eval("FRSMQuotaMB")).ToString() + " Gb" %>'></asp:Literal>
             </ItemTemplate>
         </asp:TemplateField>
-        <asp:TemplateField HeaderText="gvFolderSize" SortExpression="Size">
+        <asp:TemplateField HeaderText="gvFolderSize">
             <ItemStyle Width="15%"></ItemStyle>
             <ItemTemplate>
                 <asp:Literal id="litFolderSize" runat="server" Text='...'></asp:Literal>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationCreateOrganization.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationCreateOrganization.ascx.cs
@@ -80,14 +80,13 @@ namespace SolidCP.Portal.ExchangeServer
                         }
                     }
                 }
+                SetDefaultOrgId();
             }
 
             if (ddlDomains.Items.Count == 0)
             {
                 ddlDomains.Visible = btnCreate.Enabled = false;
             }
-
-            SetDefaultOrgId();
         }
 
         private string GetOrgId(string orgIdPolicy, string domainName, int packageId)

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx
@@ -65,7 +65,7 @@
                             <div class="input-group">
                             <asp:TextBox ID="txtSearchValue" runat="server" CssClass="form-control"></asp:TextBox>
                 <div class="input-group-btn">
-                    <CPCC:StyleButton ID="cmdSearch" Runat="server" meta:resourcekey="cmdSearch" class="btn btn-primary" CausesValidation="false" OnClick="cmdSearch_Click"><i class="fa fa-search" aria-hidden="true"></i></CPCC:StyleButton>
+                    <asp:LinkButton ID="cmdSearch" Runat="server" meta:resourcekey="cmdSearch" class="btn btn-primary" CausesValidation="false" OnClick="cmdSearch_Click"><i class="fa fa-search" aria-hidden="true"></i></asp:LinkButton>
                        </div></div></div>
                         </asp:Panel>
                     </div>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx.cs
@@ -145,7 +145,7 @@ namespace SolidCP.Portal.ExchangeServer.UserControls
 		protected void BindPopupAccounts()
 		{
 			ExchangeAccount[] accounts = ES.Services.EnterpriseStorage.SearchESAccounts(PanelRequest.ItemID,
-				ddlSearchColumn.SelectedValue, txtSearchValue.Text + "%", "");
+				ddlSearchColumn.SelectedValue, "%" + txtSearchValue.Text + "%", "");
 
             accounts = accounts.Where(x => !GetPemissions().Select(p => p.Account).Contains(x.AccountName)).ToArray();
             Array.Sort(accounts, CompareAccount);

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx.designer.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/EnterpriseStoragePermissions.ascx.designer.cs
@@ -127,7 +127,7 @@ namespace SolidCP.Portal.ExchangeServer.UserControls {
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::CPCC.StyleButton cmdSearch;
+        protected global::System.Web.UI.WebControls.LinkButton cmdSearch;
         
         /// <summary>
         /// gvPopupAccounts control.

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/App_LocalResources/RDSCollectionUsers.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/App_LocalResources/RDSCollectionUsers.ascx.de-DE.resx
@@ -159,6 +159,9 @@
   <data name="gvAccountsEmail.HeaderText" xml:space="preserve">
     <value>E-Mail</value>
   </data>
+  <data name="gvEmail.HeaderText" xml:space="preserve">
+    <value>E-Mail</value>
+  </data>
   <data name="gvPopupAccounts.EmptyDataText" xml:space="preserve">
     <value>Keine Konten gefunden.</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/App_LocalResources/RDSCollectionUsers.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/App_LocalResources/RDSCollectionUsers.ascx.resx
@@ -159,6 +159,9 @@
   <data name="gvAccountsEmail.HeaderText" xml:space="preserve">
     <value>Email</value>
   </data>
+  <data name="gvEmail.HeaderText" xml:space="preserve">
+    <value>Email</value>
+  </data>
   <data name="gvPopupAccounts.EmptyDataText" xml:space="preserve">
     <value>No accounts found.</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/RDSCollectionUsers.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/RDSCollectionUsers.ascx
@@ -21,11 +21,18 @@
                     <ItemStyle Width="10px" />
                 </asp:TemplateField>
                 <asp:TemplateField meta:resourcekey="gvUsersAccount" HeaderText="gvUsersAccount">
-                    <ItemStyle Width="80%" Wrap="false" HorizontalAlign="Left"></ItemStyle>
+                    <ItemStyle Width="40%" Wrap="false" HorizontalAlign="Left"></ItemStyle>
                     <ItemTemplate>
-                        <asp:Literal ID="litAccount" runat="server" Text='<%# Eval("DisplayName") %>'></asp:Literal><asp:Image ID="Image1" runat="server" ImageUrl='<%# GetThemedImage("Exchange/admin_16.png") %>' Visible='<%# Convert.ToBoolean(Eval("IsVIP")) %>' ImageAlign="AbsMiddle" />
+                        <asp:Literal ID="litAccount" runat="server" Text='<%# Eval("DisplayName") %>'></asp:Literal>
+                        <asp:Image ID="Image1" runat="server" ImageUrl='<%# GetThemedImage("Exchange/admin_16.png") %>' Visible='<%# Convert.ToBoolean(Eval("IsVIP")) %>' ImageAlign="AbsMiddle" />
                         <asp:HiddenField ID="hdnSamAccountName" runat="server" Value='<%# Eval("SamAccountName") %>' />
                         <asp:HiddenField ID="hdnIsVip" runat="server" Value='<%# Eval("IsVIP").ToString() %>' />
+                    </ItemTemplate>
+                </asp:TemplateField>
+                <asp:TemplateField meta:resourcekey="gvEmail" HeaderText="gvEmail">
+                    <ItemStyle Width="40%" Wrap="false" HorizontalAlign="Left"></ItemStyle>
+                    <ItemTemplate>
+                        <asp:Literal ID="litEmail" runat="server" Text='<%# Eval("PrimaryEmailAddress") %>'></asp:Literal>
                     </ItemTemplate>
                 </asp:TemplateField>
                 <asp:TemplateField meta:resourcekey="gvSetupInstructions">

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/RDSCollectionUsers.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/RDS/UserControls/RDSCollectionUsers.ascx.cs
@@ -285,6 +285,7 @@ namespace SolidCP.Portal.RDS.UserControls
                 OrganizationUser user = new OrganizationUser();
                 user.AccountName = (string)gvUsers.DataKeys[i][0];
                 user.DisplayName = ((Literal)row.FindControl("litAccount")).Text;
+                user.PrimaryEmailAddress = ((Literal)row.FindControl("litEmail")).Text;
                 user.SamAccountName = ((HiddenField)row.FindControl("hdnSamAccountName")).Value;
                 user.IsVIP = Convert.ToBoolean(((HiddenField)row.FindControl("hdnIsVip")).Value);
 
@@ -313,6 +314,7 @@ namespace SolidCP.Portal.RDS.UserControls
                     {
                         AccountName = (string)gvPopupAccounts.DataKeys[i][0],
                         DisplayName = ((Literal)row.FindControl("litDisplayName")).Text,
+                        PrimaryEmailAddress = ((Literal)row.FindControl("litPrimaryEmailAddress")).Text,
                         SamAccountName = ((HiddenField)row.FindControl("hdnSamName")).Value,
                         IsVIP = Convert.ToBoolean(((HiddenField)row.FindControl("hdnLocalAdmin")).Value)
                     });

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SpaceQuotas.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SpaceQuotas.ascx
@@ -157,19 +157,19 @@
         <td class="Normal"><scp:Quota ID="quotaRdsUsers" runat="server" QuotaName="RDS.Users" DisplayGauge="True" /></td>
     </tr>
      <tr ID="pnlVPS2012Servers" runat="server">
-        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012Servers" runat="server" meta:resourcekey="lblVPS2012Servers" Text="VPS 2012 Servers:"></asp:Label></td>
+        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012Servers" runat="server" meta:resourcekey="lblVPS2012Servers" Text="VPS Servers:"></asp:Label></td>
         <td class="Normal"><scp:Quota ID="quotavps2012servers" runat="server" QuotaName="VPS2012.ServersNumber" DisplayGauge="True" /></td>
     </tr>
     <tr ID="pnlVPS2012CpuQuota" runat="server">
-        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012CpuQuota" runat="server" meta:resourcekey="lblVPS2012CpuQuota" Text="VPS 2012 Cpu:"></asp:Label></td>
+        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012CpuQuota" runat="server" meta:resourcekey="lblVPS2012CpuQuota" Text="VPS Cpu:"></asp:Label></td>
         <td class="Normal"><scp:Quota ID="quotavps2012cpuquota" runat="server" QuotaName="VPS2012.CpuNumber" DisplayGauge="True" /></td>
     </tr>
     <tr ID="pnlVPS2012RamQuota" runat="server">
-        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012RamQuota" runat="server" meta:resourcekey="lblVPS2012RamQuota" Text="VPS 2012 Ram, MB:"></asp:Label></td>
+        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012RamQuota" runat="server" meta:resourcekey="lblVPS2012RamQuota" Text="VPS Ram, MB:"></asp:Label></td>
         <td class="Normal"><scp:Quota ID="quotavps2012ramquota" runat="server" QuotaName="VPS2012.Ram" DisplayGauge="True" /></td>
     </tr>
     <tr ID="pnlVPS2012HddQuota" runat="server">
-        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012HddQuota" runat="server" meta:resourcekey="lblVPS2012HddQuota" Text="VPS 2012 Hdd, GB:"></asp:Label></td>
+        <td class="SubHead" nowrap><asp:Label ID="lblVPS2012HddQuota" runat="server" meta:resourcekey="lblVPS2012HddQuota" Text="VPS Hdd, GB:"></asp:Label></td>
         <td class="Normal"><scp:Quota ID="quotavps2012hddquota" runat="server" QuotaName="VPS2012.Hdd" DisplayGauge="True" /></td>
     </tr>
 </table>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsSnapshots.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsSnapshots.ascx
@@ -21,7 +21,7 @@
 				            <td valign="top">
 				            
                                 <div class="FormButtonsBarClean">
-                                    <CPCC:StyleButton id="btnTakeSnapshot" CssClass="btn btn-success" runat="server" onclick="btnTakeSnapshot_Click"> <i class="fa fa-check">&nbsp;</i>&nbsp;<asp:Localize runat="server" meta:resourcekey="btnTakeSnapshotText"/> </CPCC:StyleButton>
+                                    <CPCC:StyleButton id="btnTakeSnapshot" CssClass="btn btn-success" runat="server" onclick="btnTakeSnapshot_Click" meta:resourcekey="btnTakeSnapshot"> <i class="fa fa-check">&nbsp;</i>&nbsp;<asp:Localize runat="server" meta:resourcekey="btnTakeSnapshotText"/> </CPCC:StyleButton>
                                 </div>
                                 <br />
                                 
@@ -79,7 +79,7 @@
 		    </div>
 	    </div>
 
-<asp:Panel ID="RenamePanel" runat="server" style="display:none;">
+<asp:Panel ID="RenamePanel" runat="server" style="display:none;" Width="380">
 	 <div class="widget">
              <div class="widget-header clearfix">
                            <h3><i class="fa fa-i-cursor"></i>  <asp:Localize ID="locRenameSnapshot" runat="server" Text="Rename snapshot" meta:resourcekey="locRenameSnapshot"></asp:Localize></h3>


### PR DESCRIPTION
# Description

[RDS] Remove Authenticated Users from collections GPO
[HyperV2012R2+] Move clustered VM to another host if not enough memory to start
[HyperV2012R2+] Interface update fix when creating or deleting snapshots
[WebDavPortal] Ability to create subfolders
[WebDavPortal] Delete non empty folder with confirm dialog
[WebDavPortal] Checking users permissions when creating a subfolder
[RDS] Remove not used RDS Server from deployment
[Hosted Organization] Activate users in OU, after activation of the SolidCP account.
Add custom DNS records from RDS service
[DNS] Add Service DNS records at Domain creation
[Shared Folders] Search and sort fixed
[Shared Folders] Folder Permissions -> Add - Search fixed
[RDS] RDS Collection -> RDS Users - Add Email column

Fixes # (issue)
#33, #36, #38, #40 