### PR TITLE
Modified AddUser API to allow optional notes to be added when creating a user

### DIFF
--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Users/UserController.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Users/UserController.cs
@@ -38,6 +38,7 @@ using System.Xml;
 using System.Net.Mail;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using System.Linq;
 
 namespace SolidCP.EnterpriseServer
 {
@@ -390,6 +391,29 @@ namespace SolidCP.EnterpriseServer
 		{
 			// get users from database
 			return DataProvider.GetUsers(SecurityContext.User.UserId, ownerId, recursive);
+		}
+
+		public static int AddUser(UserInfo user, bool sendLetter, string password, string[] notes)
+		{
+			int userId = AddUser(user, sendLetter, password);
+
+			if (userId > 0 && notes != null)
+			{
+				foreach(string note in notes)
+				{
+					// user added successfully, save the notes
+					DataProvider.AddComment(
+						SecurityContext.User.UserId,
+						"USER", 
+						userId,
+						note, 
+						1
+						);
+				}
+
+			}
+			
+			return userId;
 		}
 
 		public static int AddUser(UserInfo user, bool sendLetter, string password)

--- a/SolidCP/Sources/SolidCP.EnterpriseServer/esUsers.asmx.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer/esUsers.asmx.cs
@@ -142,9 +142,9 @@ namespace SolidCP.EnterpriseServer
         }
 
         [WebMethod]
-        public int AddUser(UserInfo user, bool sendLetter, string password)
+        public int AddUser(UserInfo user, bool sendLetter, string password, string[] notes)
         {
-            return UserController.AddUser(user, sendLetter, password);
+            return UserController.AddUser(user, sendLetter, password, notes);
         }
 
         [WebMethod]


### PR DESCRIPTION
# Description
Enhanced the AddUser API to allow notes to be added to customers account at the time of account creation. An optional string array can be provided where each string is added as a separate note to the customers account.


Fixes # (issue)
The User entity has a comments field which appears to have been depreciated in favour of using the customer notes functionality. The Enterprise Server API for creating users had not been updated for this scenario. 

# How Has This Been Tested?

Tested locally.

- [X ] Built code to ensure it has no errors

# Checklist:
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings

