### PR TITLE
Feature/improve exchange mailbox setup letter

### DIFF
--- a/SolidCP/Database/update_db.sql
+++ b/SolidCP/Database/update_db.sql
@@ -11134,7 +11134,7 @@ GO
 -- Exchange setup EMAIL TEMPLATE
 IF NOT EXISTS (SELECT * FROM [dbo].[UserSettings] WHERE [UserID] = 1 AND [SettingsName]= N'ExchangeMailboxSetupLetter' AND [PropertyName]= N'From' )
 BEGIN
-INSERT [dbo].[UserSettings] ([UserID], [SettingsName], [PropertyName], [PropertyValue]) VALUES (1, N'ExchangeMailboxSetupLetter', N'From', N'')
+INSERT [dbo].[UserSettings] ([UserID], [SettingsName], [PropertyName], [PropertyValue]) VALUES (1, N'ExchangeMailboxSetupLetter', N'From', N'support@HostingCompany.com')
 END
 GO
 

--- a/SolidCP/Database/update_db.sql
+++ b/SolidCP/Database/update_db.sql
@@ -11131,19 +11131,7 @@ END
 GO
 
 
-
 -- Exchange setup EMAIL TEMPLATE
-IF NOT EXISTS (SELECT * FROM [dbo].[UserSettings] WHERE [UserID] = 1 AND [SettingsName]= N'ExchangeMailboxSetupLetter' AND [PropertyName]= N'From' )
-BEGIN
-INSERT [dbo].[UserSettings] ([UserID], [SettingsName], [PropertyName], [PropertyValue]) VALUES (1, N'ExchangeMailboxSetupLetter', N'From', N'')
-END
-GO
-
-DECLARE @ExchangeMailboxSetupLetterHtmlBody nvarchar(max)
--- Exchange setup EMAIL TEMPLATE
-
-
-
 IF NOT EXISTS (SELECT * FROM [dbo].[UserSettings] WHERE [UserID] = 1 AND [SettingsName]= N'ExchangeMailboxSetupLetter' AND [PropertyName]= N'From' )
 BEGIN
 INSERT [dbo].[UserSettings] ([UserID], [SettingsName], [PropertyName], [PropertyValue]) VALUES (1, N'ExchangeMailboxSetupLetter', N'From', N'')


### PR DESCRIPTION
The "Exchange Mailbox Setup Letter" by default does not have a From address filled in. This is in contrast to the other letters, where FROM is populated with 'support@hostingcompany.com'.

I found and modified the update sql script that is responsible for this.
But first I remove two SQL statements that duplicated the statements just before them.