### PR TITLE
[HyperVController2012] - added an exception if osTemplateFile was not found

### DIFF
--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
@@ -570,12 +570,14 @@ namespace SolidCP.EnterpriseServer
 
                 try
                 {
+                    bool isTemplateExist = false;
                     LibraryItem[] osTemplates = GetOperatingSystemTemplates(vm.PackageId);
                     foreach (LibraryItem item in osTemplates)
                     {
                         if (String.Compare(item.Path, osTemplateFile, true) == 0)
                         {
                             osTemplate = item;
+                            isTemplateExist = true;
 
                             // check minimal disk size
                             if (osTemplate.DiskSize > 0 && vm.HddSize < osTemplate.DiskSize)
@@ -593,6 +595,9 @@ namespace SolidCP.EnterpriseServer
                             vm.RemoteDesktopEnabled = osTemplate.RemoteDesktop;
                             break;
                         }
+                    }
+                    if (!isTemplateExist) { //give a description of the error for Third party services if they use SOAP
+                        throw new Exception("The template " + osTemplateFile + " was not found in the HyperV Service Template Library.");
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
# Description

Gives a description of the error for Third party services if they use SOAP. At this moment if we pass a wrong osTemplateFile, we don't know why a creating VM crashing