### PR TITLE
Update configurableoptions.php

### DIFF
--- a/SolidCP.WHMCSModule/modules/addons/solidcp_module/lib/configurableoptions.php
+++ b/SolidCP.WHMCSModule/modules/addons/solidcp_module/lib/configurableoptions.php
@@ -54,7 +54,7 @@ Class solidcp_configurableoptions{
     public function getConfigurableOptions(){
         try{
             $this->configurableoptions = Capsule::select("select concat(g.name, ' -> ', o.optionname, ' -> ', os.optionname) as name, c.whmcs_id as whmcs_id, c.scp_id as scp_id, os.hidden as hidden from ".SOLIDCP_CONFIGURABLE_OPTIONS_TABLE." as c
-left join tblproductconfigoptionssub as os on c.whmcs_id=os.id
+left join tblproductconfigoptionssub as os on c.whmcs_id=os.configid
 left join tblproductconfigoptions as o on os.configid=o.id
 left join tblproductconfiggroups as g on o.gid=g.id
 order by g.name,  o.`order`, os.sortorder");


### PR DESCRIPTION
Fix for "Configurable Option Name" not showing in the Configurable Options tab.

# Description

The "Configurable Option Name" doesn't populate in the "Configurable Options" tab of the WHMCS SolidCP Addon settings. This is because the tblproductconfigoptionssub table is joined to the solid_configurable table with the wrong column.

# How Has This Been Tested?

Yes, it's running fine in my environment (WHMCS 8.0.4).