### PR TITLE
Added new Username pattern

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/App_LocalResources/Organizations_Settings.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/App_LocalResources/Organizations_Settings.ascx.de-DE.resx
@@ -135,6 +135,9 @@
   <data name="listItemAppendOrgId.Text" xml:space="preserve">
     <value>OrgID anhängen</value>
   </data>
+  <data name="listItemAppendCounterIfNeeded.Text" xml:space="preserve">
+    <value>Bei Bedarf Zähler anhängen</value>
+  </data>  
   <data name="lblArchiveStorageSpace.Text" xml:space="preserve">
     <value>Archiv-Speicherpfad:</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/App_LocalResources/Organizations_Settings.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/App_LocalResources/Organizations_Settings.ascx.resx
@@ -135,6 +135,9 @@
   <data name="listItemAppendOrgId.Text" xml:space="preserve">
     <value>Append OrgID</value>
   </data>
+  <data name="listItemAppendCounterIfNeeded.Text" xml:space="preserve">
+    <value>Append Counter if needed</value>
+  </data>  
   <data name="lblArchiveStorageSpace.Text" xml:space="preserve">
     <value>Archive Storage Path:</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/Organizations_Settings.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/Organizations_Settings.ascx
@@ -29,6 +29,7 @@
             <asp:DropDownList runat="server" ID="UserNameFormatDropDown">
                 <asp:ListItem Value="1" meta:resourcekey="listItemStandard"/>
                 <asp:ListItem Value="2" meta:resourcekey="listItemAppendOrgId"/>
+                <asp:ListItem Value="3" meta:resourcekey="listItemAppendCounterIfNeeded"/>
             </asp:DropDownList>
         </td>
     </tr>


### PR DESCRIPTION
Currently there are two username pattern.
The standard pattern uses the name and always appended with a long counter.
At first you think that the user is never confronted with that username. But that is not true. It pops up in various places in the communication to the customer (can't remember where)

I hated that so much that I took the time to create another one.
I uses the name and only appends a short counter if needed.

