### PR TITLE
[WHMCS Module] Fix for getConfigurableOptions

### DIFF
--- a/SolidCP.WHMCSModule/modules/addons/solidcp_module/lib/configurableoptions.php
+++ b/SolidCP.WHMCSModule/modules/addons/solidcp_module/lib/configurableoptions.php
@@ -54,7 +54,7 @@ Class solidcp_configurableoptions{
     public function getConfigurableOptions(){
         try{
             $this->configurableoptions = Capsule::select("select concat(g.name, ' -> ', o.optionname, ' -> ', os.optionname) as name, c.whmcs_id as whmcs_id, c.scp_id as scp_id, os.hidden as hidden from ".SOLIDCP_CONFIGURABLE_OPTIONS_TABLE." as c
-left join tblproductconfigoptionssub as os on c.whmcs_id=os.configid
+left join tblproductconfigoptionssub as os on c.whmcs_id=os.id
 left join tblproductconfigoptions as o on os.configid=o.id
 left join tblproductconfiggroups as g on o.gid=g.id
 order by g.name,  o.`order`, os.sortorder");


### PR DESCRIPTION
# Description

solidcp_configurable.whmcs_id should be connected to tblproductconfigoptionssub.id
One configurable option (tblproductconfigoptions) can have multiple sub-options (tblproductconfigoptionssub) (if it's a dropdown or radio button) and each sub-option must then be linked to SolidCP and not just whole configurable option.

Fixes # (issue)

https://solidcp.com/forum/question/whmcs-and-configurable-options-names-not-displaying/