### PR TITLE
[HyperV2012R2+] Fix for additional HDDs and unlimited quota (7ab03e8)

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VdcCreateServer.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VdcCreateServer.ascx.cs
@@ -680,12 +680,12 @@ namespace SolidCP.Portal.VPS2012
                 {
                     int availSize = hddQuota.QuotaAllocatedValue - hddQuota.QuotaUsedValue;
                     freeHddGb = availSize < 0 ? 0 : availSize;
+                    freeHddGb -= Utils.ParseInt(txtHdd.Text.Trim());
+                    foreach (AdditionalHdd hdd in hdds)
+                    {
+                        if (hdd.DiskSize > 0) freeHddGb -= hdd.DiskSize;
+                    }
                 }
-            }
-            freeHddGb -= Utils.ParseInt(txtHdd.Text.Trim());
-            foreach (AdditionalHdd hdd in hdds)
-            {
-                if (hdd.DiskSize > 0) freeHddGb -= hdd.DiskSize;
             }
             hdds.Add(new AdditionalHdd(freeHddGb, ""));
             RebindAdditionalHdd(hdds);

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsEditConfiguration.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsEditConfiguration.ascx.cs
@@ -377,11 +377,11 @@ namespace SolidCP.Portal.VPS2012
                 {
                     int availSize = hddQuota.QuotaAllocatedValue - hddQuota.QuotaUsedValue;
                     freeHddGb = availSize < 0 ? 0 : availSize;
+                    foreach (AdditionalHdd hdd in hdds)
+                    {
+                        if (hdd.DiskSize > 0 && String.IsNullOrEmpty(hdd.DiskPath)) freeHddGb -= hdd.DiskSize;
+                    }
                 }
-            }
-            foreach (AdditionalHdd hdd in hdds)
-            {
-                if (hdd.DiskSize > 0 && String.IsNullOrEmpty(hdd.DiskPath)) freeHddGb -= hdd.DiskSize;
             }
             hdds.Add(new AdditionalHdd(freeHddGb, ""));
             RebindAdditionalHdd(hdds);


### PR DESCRIPTION
# Description

[HyperV2012R2+] Fix for additional HDDs and unlimited quota (7ab03e8)

Fixes # (issue)

A negative number is displayed when the quota is unlimited and a new HDD is added