### PR TITLE
[HyperV2012R2+] Fixed incorrect recording events in Audit log.

### DIFF
--- a/Languages/Resources.xml
+++ b/Languages/Resources.xml
@@ -13377,6 +13377,106 @@
     <DefaultValue>Job failed to start with the following code: {0}</DefaultValue>
   </Resource>
   <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_ADD_EXTERNAL_IP</Key>
+    <DefaultValue>Add external IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_ADD_PRIVATE_IP</Key>
+    <DefaultValue>Add private IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_APPLY_SNAPSHOT</Key>
+    <DefaultValue>Apply VPS snapshot</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_CHANGE_ADMIN_PASSWORD</Key>
+    <DefaultValue>Change administrator password</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_CHANGE_STATE</Key>
+    <DefaultValue>Change VPS state</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_DELETE</Key>
+    <DefaultValue>Delete VPS</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_DELETE_EXTERNAL_IP</Key>
+    <DefaultValue>Delete external IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_DELETE_PRIVATE_IP</Key>
+    <DefaultValue>Delete private IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_DELETE_SNAPSHOT</Key>
+    <DefaultValue>Delete VPS snapshot</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_DELETE_SNAPSHOT_SUBTREE</Key>
+    <DefaultValue>Delete VPS snapshot subtree</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_EJECT_DVD_DISK</Key>
+    <DefaultValue>Eject DVD disk</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_INSERT_DVD_DISK</Key>
+    <DefaultValue>Insert DVD disk</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_RENAME_SNAPSHOT</Key>
+    <DefaultValue>Rename VPS snapshot</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_RESTORE_EXTERNAL_IP</Key>
+    <DefaultValue>Restore external IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_RESTORE_PRIVATE_IP</Key>
+    <DefaultValue>Restore private IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_SET_PRIMARY_EXTERNAL_IP</Key>
+    <DefaultValue>Set primary external IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_SET_PRIMARY_PRIVATE_IP</Key>
+    <DefaultValue>Set primary private IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_TAKE_SNAPSHOT</Key>
+    <DefaultValue>Take VPS snapshot</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_UPDATE_CONFIGURATION</Key>
+    <DefaultValue>Update VPS configuration</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>AuditLogTask.VPS2012_UPDATE_HOSTNAME</Key>
+    <DefaultValue>Update host name</DefaultValue>
+  </Resource>
+  <Resource>
     <File>DesktopModules\SolidCP\App_LocalResources\ApplyEnableHardQuotaFeature.ascx.resx</File>
     <Key>btnUpdate.Text</Key>
     <DefaultValue>Apply</DefaultValue>

--- a/Languages/Resources.xml
+++ b/Languages/Resources.xml
@@ -13477,6 +13477,36 @@
     <DefaultValue>Update host name</DefaultValue>
   </Resource>
   <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_ADD_EXTERNAL_IP</Key>
+    <DefaultValue>Assigning external IP addresses</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_ADD_PRIVATE_IP</Key>
+    <DefaultValue>Assigning private IP addresses</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_DELETE_EXTERNAL_IP</Key>
+    <DefaultValue>Delete external IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_DELETE_PRIVATE_IP</Key>
+    <DefaultValue>Delete private IP</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_SET_PRIMARY_EXTERNAL_IP</Key>
+    <DefaultValue>Setting external primary IP address</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>TaskActivity.VPS2012_SET_PRIMARY_PRIVATE_IP</Key>
+    <DefaultValue>Setting private primary IP address</DefaultValue>
+  </Resource>
+  <Resource>
     <File>DesktopModules\SolidCP\App_LocalResources\ApplyEnableHardQuotaFeature.ascx.resx</File>
     <Key>btnUpdate.Text</Key>
     <DefaultValue>Apply</DefaultValue>

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VM/IpAddressExternalHelper.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VM/IpAddressExternalHelper.cs
@@ -90,7 +90,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers.VM
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "ADD_EXTERNAL_IP", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "ADD_EXTERNAL_IP", vm.Id, vm.Name, vm.PackageId);
 
             // Get VLAN of 1st Network Interface
             if (vlan == -1)
@@ -181,7 +181,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers.VM
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "SET_PRIMARY_EXTERNAL_IP", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "SET_PRIMARY_EXTERNAL_IP", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VM/IpAddressPrivateHelper.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VM/IpAddressPrivateHelper.cs
@@ -105,7 +105,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers.VM
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "ADD_PRIVATE_IP", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "ADD_PRIVATE_IP", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -317,7 +317,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers.VM
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "SET_PRIMARY_PRIVATE_IP", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "SET_PRIMARY_PRIVATE_IP", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ChangeVirtualMachineAdministratorPasswordHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ChangeVirtualMachineAdministratorPasswordHandler.cs
@@ -46,7 +46,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "CHANGE_ADMIN_PASSWORD", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "CHANGE_ADMIN_PASSWORD", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ChangeVirtualMachineStateHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ChangeVirtualMachineStateHandler.cs
@@ -17,7 +17,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
         public static ResultObject ChangeVirtualMachineState(int itemId, VirtualMachineRequestedState state)
         {
             // start task
-            ResultObject res = TaskManager.StartResultTask<ResultObject>("VPS", "CHANGE_STATE");
+            ResultObject res = TaskManager.StartResultTask<ResultObject>("VPS2012", "CHANGE_STATE");
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/DeleteVirtualMachineHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/DeleteVirtualMachineHandler.cs
@@ -48,7 +48,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "DELETE", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "DELETE", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineHostNameHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineHostNameHandler.cs
@@ -43,7 +43,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "UPDATE_HOSTNAME", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "UPDATE_HOSTNAME", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineResourceHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineResourceHandler.cs
@@ -115,7 +115,7 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "UPDATE_CONFIGURATION", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "UPDATE_CONFIGURATION", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/VirtualizationServerController2012.cs
@@ -607,7 +607,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "INSERT_DVD_DISK", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "INSERT_DVD_DISK", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -663,7 +663,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "EJECT_DVD_DISK", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "EJECT_DVD_DISK", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -738,7 +738,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "TAKE_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "TAKE_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -808,7 +808,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "APPLY_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "APPLY_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -874,7 +874,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "RENAME_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "RENAME_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -923,7 +923,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "DELETE_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "DELETE_SNAPSHOT", vm.Id, vm.Name, vm.PackageId);
 
             try
             {
@@ -979,7 +979,7 @@ namespace SolidCP.EnterpriseServer
             #endregion
 
             // start task
-            res = TaskManager.StartResultTask<ResultObject>("VPS", "DELETE_SNAPSHOT_SUBTREE", vm.Id, vm.Name, vm.PackageId);
+            res = TaskManager.StartResultTask<ResultObject>("VPS2012", "DELETE_SNAPSHOT_SUBTREE", vm.Id, vm.Name, vm.PackageId);
 
             try
             {

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
@@ -6828,4 +6828,22 @@
   <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
     <value>تحديث اسم المضيف</value>
   </data>
+  <data name="TaskActivity.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>تعيين عناوين IP الخارجية</value>
+  </data>
+  <data name="TaskActivity.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>تعيين عناوين IP الخاصة</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>Delete external IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>Delete private IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>تعيين عنوان IP الأساسي الخارجي</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>تعيين عنوان IP الأساسي الخاص</value>
+  </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="YesNo.False" xml:space="preserve">
     <value>لا</value>
@@ -2816,12 +2816,6 @@
   </data>
   <data name="AuditLogTask.REMOTE_DESKTOP_SERVICES_SET_RDS_SERVER_NEW_CONNECTIONS_ALLOWED" xml:space="preserve">
     <value>تعيين اتصال جديد RDS مسموح به</value>
-  </data>
-  <data name="AuditLogTask.VPS2012_CREATE" xml:space="preserve">
-    <value>إنشاء VM</value>
-  </data>
-  <data name="AuditLogTask.VPS2012_REINSTALL" xml:space="preserve">
-    <value>أعد تثبيت VM</value>
   </data>
   <data name="AuditLogTask.HOSTING_SPACE_ADD" xml:space="preserve">
     <value>أضف</value>
@@ -6767,5 +6761,71 @@
   </data>
   <data name="Quota.RDS.DisableUserShutdown" xml:space="preserve">
     <value>تعطيل المستخدم من إيقاف تشغيل خادم RDS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>أضف IP خارجي</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>إضافة IP الخاص</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_APPLY_SNAPSHOT" xml:space="preserve">
+    <value>تنفيذ لقطة VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_ADMIN_PASSWORD" xml:space="preserve">
+    <value>تغيير كلمة مرور المسؤول</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_STATE" xml:space="preserve">
+    <value>قم بتغيير حالة VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CREATE" xml:space="preserve">
+    <value>قم بإنشاء VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE" xml:space="preserve">
+    <value>حذف VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>احذف IP الخارجي</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>حذف IP الخاص</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT" xml:space="preserve">
+    <value>حذف لقطة VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT_SUBTREE" xml:space="preserve">
+    <value>حذف موقع الويب بعد الأيام:</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_EJECT_DVD_DISK" xml:space="preserve">
+    <value>إخراج قرص DVD</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_INSERT_DVD_DISK" xml:space="preserve">
+    <value>أدخل قرص DVD</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_REINSTALL" xml:space="preserve">
+    <value>أعد تثبيت VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RENAME_SNAPSHOT" xml:space="preserve">
+    <value>أعد تسمية لقطة VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_EXTERNAL_IP" xml:space="preserve">
+    <value>استعادة IP الخارجي</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_PRIVATE_IP" xml:space="preserve">
+    <value>استعادة IP الخاص</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>قم بتعيين عنوان IP الخارجي الأساسي</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>تعيين عنوان IP الأساسي الخاص</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_TAKE_SNAPSHOT" xml:space="preserve">
+    <value>خذ لقطة VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_CONFIGURATION" xml:space="preserve">
+    <value>تحديث تكوين VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
+    <value>تحديث اسم المضيف</value>
   </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
@@ -2835,12 +2835,6 @@
   <data name="AuditLogTask.REMOTE_DESKTOP_SERVICES_SET_RDS_SERVER_NEW_CONNECTIONS_ALLOWED" xml:space="preserve">
     <value>RDS - neue Verbindungen Einstellen</value>
   </data>
-  <data name="AuditLogTask.VPS2012_CREATE" xml:space="preserve">
-    <value>VM erstellen</value>
-  </data>
-  <data name="AuditLogTask.VPS2012_REINSTALL" xml:space="preserve">
-    <value>VM Reinstall</value>
-  </data>
   <data name="AuditLogTask.HOSTING_SPACE_ADD" xml:space="preserve">
     <value>Hinzufügen</value>
   </data>
@@ -6785,5 +6779,71 @@
   </data>
   <data name="TaskActivity.VPS_JOB_START_ERROR" xml:space="preserve">
     <value>Job failed to start with the following code: {0}</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>Externe IP hinzufügen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>Private IP hinzufügen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_APPLY_SNAPSHOT" xml:space="preserve">
+    <value>VPS-Snapshot anwenden</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_ADMIN_PASSWORD" xml:space="preserve">
+    <value>Administrator-Passwort ändern</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_STATE" xml:space="preserve">
+    <value>VPS-Status ändern</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CREATE" xml:space="preserve">
+    <value>VPS erstellen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE" xml:space="preserve">
+    <value>VPS löschen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>Externe IP löschen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>Private IP löschen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT" xml:space="preserve">
+    <value>VPS Snapshot löschen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT_SUBTREE" xml:space="preserve">
+    <value>VPS Snapshot-Unterstruktur löschen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_EJECT_DVD_DISK" xml:space="preserve">
+    <value>DVD-Disk auswerfen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_INSERT_DVD_DISK" xml:space="preserve">
+    <value>DVD-Disk einlegen...</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_REINSTALL" xml:space="preserve">
+    <value>VPS neu installieren</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RENAME_SNAPSHOT" xml:space="preserve">
+    <value>VPS-Snapshot umbenennen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_EXTERNAL_IP" xml:space="preserve">
+    <value>Restore external IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_PRIVATE_IP" xml:space="preserve">
+    <value>Restore private IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>Primäre externe IP festlegen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>Primäre private IP festlegen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_TAKE_SNAPSHOT" xml:space="preserve">
+    <value>VPS-Snapshot erstellen</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_CONFIGURATION" xml:space="preserve">
+    <value>VPS-Konfiguration aktualisieren</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
+    <value>Hostnamen aktualisieren</value>
   </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
@@ -6846,4 +6846,22 @@
   <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
     <value>Hostnamen aktualisieren</value>
   </data>
+  <data name="TaskActivity.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>Externe IP-Adressen werden zugewiesen</value>
+  </data>
+  <data name="TaskActivity.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>Private IP-Adressen werden zugewiesen</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>Delete external IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>Delete private IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>Primäre externe IP-Adresse wird gesetzt</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>Primäre private IP-Adresse wird gesetzt</value>
+  </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
@@ -6919,4 +6919,22 @@
   <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
     <value>Update host name</value>
   </data>
+  <data name="TaskActivity.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>Assigning external IP addresses</value>
+  </data>
+  <data name="TaskActivity.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>Assigning private IP addresses</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>Delete external IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>Delete private IP</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>Setting external primary IP address</value>
+  </data>
+  <data name="TaskActivity.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>Setting private primary IP address</value>
+  </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
@@ -6859,4 +6859,64 @@
   <data name="TaskActivity.VPS_JOB_START_ERROR" xml:space="preserve">
     <value>Job failed to start with the following code: {0}</value>
   </data>
+  <data name="AuditLogTask.VPS2012_ADD_EXTERNAL_IP" xml:space="preserve">
+    <value>Add external IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_ADD_PRIVATE_IP" xml:space="preserve">
+    <value>Add private IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_APPLY_SNAPSHOT" xml:space="preserve">
+    <value>Apply VPS snapshot</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_ADMIN_PASSWORD" xml:space="preserve">
+    <value>Change administrator password</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_CHANGE_STATE" xml:space="preserve">
+    <value>Change VPS state</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE" xml:space="preserve">
+    <value>Delete VPS</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_EXTERNAL_IP" xml:space="preserve">
+    <value>Delete external IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_PRIVATE_IP" xml:space="preserve">
+    <value>Delete private IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT" xml:space="preserve">
+    <value>Delete VPS snapshot</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_DELETE_SNAPSHOT_SUBTREE" xml:space="preserve">
+    <value>Delete VPS snapshot subtree</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_EJECT_DVD_DISK" xml:space="preserve">
+    <value>Eject DVD disk</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_INSERT_DVD_DISK" xml:space="preserve">
+    <value>Insert DVD disk</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RENAME_SNAPSHOT" xml:space="preserve">
+    <value>Rename VPS snapshot</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_EXTERNAL_IP" xml:space="preserve">
+    <value>Restore external IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_RESTORE_PRIVATE_IP" xml:space="preserve">
+    <value>Restore private IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_EXTERNAL_IP" xml:space="preserve">
+    <value>Set primary external IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_SET_PRIMARY_PRIVATE_IP" xml:space="preserve">
+    <value>Set primary private IP</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_TAKE_SNAPSHOT" xml:space="preserve">
+    <value>Take VPS snapshot</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_CONFIGURATION" xml:space="preserve">
+    <value>Update VPS configuration</value>
+  </data>
+  <data name="AuditLogTask.VPS2012_UPDATE_HOSTNAME" xml:space="preserve">
+    <value>Update host name</value>
+  </data>
 </root>


### PR DESCRIPTION
# Description

The logs were recorded to nowhere because was a wrong tag.