### PR TITLE
Fix issue #136

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx
@@ -48,16 +48,14 @@
         </div>
     </div>
      <div class="row">
-         <div class="col-sm-6">
+         <div class="col-sm-12">
+            <CPCC:StyleButton ID="StyleButton2" runat="server" CssClass="btn btn-success pull-right" OnClick="btnVerifyPin_Click">
+                <asp:Localize runat="server" meta:resourcekey="btnLogin" />&nbsp;<i class="fa fa-sign-in" aria-hidden="true"></i>
+            </CPCC:StyleButton>
             <CPCC:StyleButton runat="server" id="StyleButton1" CssClass="btn btn-succsess" OnClick="btnResendPin_Click">
                 <asp:Localize runat="server" meta:resourcekey="btResendPin" />
             </CPCC:StyleButton>
         </div>
-        <div class="col-sm-6">
-            <CPCC:StyleButton ID="StyleButton2" runat="server" CssClass="btn btn-success pull-right" OnClick="btnVerifyPin_Click">
-                <asp:Localize runat="server" meta:resourcekey="btnLogin" />&nbsp;<i class="fa fa-sign-in" aria-hidden="true"></i></CPCC:StyleButton>
-        </div>
-         
     </div>
 </div>
 <div class="panel-footer">


### PR DESCRIPTION
# Description

Changes the pin entry form so the login button is first in the page code before the "Resend Pin Code" button.

The two column layout is changed to a 1 column layout for the buttons so the Login button floats right when added in front of the Resend Pin Code button.

This allows the user to press the enter key after PIN entry and login instead of resending the PIN code.

Fixes #136 

# How Has This Been Tested?

Tested in Chrome:
- [x] Pressing enter after pin entry will select login button
- [x] Clicking resend pin code button with mouse will still resend the pin code

Tested in Firefox:
- [x] Pressing enter after pin entry will select login button


- [ ] Built code to ensure it has no errors

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
