### PR TITLE
Mfa fixes + improvements

### DIFF
--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Base/System/SystemSettings.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Base/System/SystemSettings.cs
@@ -53,9 +53,10 @@ namespace SolidCP.EnterpriseServer
         public const string WEBDAV_PORTAL_SETTINGS = "WebdavPortalSettings";
         public const string TWILIO_SETTINGS = "TwilioSettings";
         public const string ACCESS_IP_SETTINGS = "AccessIpsSettings";
+		public const string AUTHENTICATION_SETTINGS = "AuthenticationSettings";
 
-        //Keys
-        public const string TWILIO_ACTIVE_KEY = "TwilioActive";
+		//Keys
+		public const string TWILIO_ACTIVE_KEY = "TwilioActive";
         public const string TWILIO_ACCOUNTSID_KEY = "TwilioAccountSid";
         public const string TWILIO_AUTHTOKEN_KEY = "TwilioAuthToken";
         public const string TWILIO_PHONEFROM_KEY = "TwilioPhoneFrom";
@@ -69,8 +70,12 @@ namespace SolidCP.EnterpriseServer
         public const string WPI_MAIN_FEED_KEY = "WpiMainFeedUrl";
         public const string FEED_ULS_KEY = "FeedUrls";
 
-        // Constant for IPAccess
-        public const string ACCESS_IPs = "AccessIps";
+		//Mfa token app display name
+		public const string MFA_TOKEN_APP_DISPLAY_NAME = "MfaTokenAppDisplayName";
+		public const string MFA_CAN_PEER_CHANGE_MFA = "CanPeerChangeMfa";
+
+		// Constant for IPAccess
+		public const string ACCESS_IPs = "AccessIps";
 
         // Constants for Reporting Transforms
         public const string BANDWIDTH_TRANSFORM = "BandwidthXLST";

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Client/UsersProxy.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Client/UsersProxy.cs
@@ -210,7 +210,15 @@ namespace SolidCP.EnterpriseServer
         public event DeleteUserThemeSettingCompletedEventHandler DeleteUserThemeSettingCompleted;
 
         /// <remarks/>
-		[System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/enterpriseserver/UpdateUserMfa", RequestNamespace = "http://smbsaas/solidcp/enterpriseserver", ResponseNamespace = "http://smbsaas/solidcp/enterpriseserver", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
+        [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/enterpriseserver/CanUserChangeMfa", RequestNamespace = "http://smbsaas/solidcp/enterpriseserver", ResponseNamespace = "http://smbsaas/solidcp/enterpriseserver", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
+        public bool CanUserChangeMfa(int changeUserId)
+        {
+            object[] results = this.Invoke("CanUserChangeMfa", new object[] {
+                        changeUserId });
+            return ((bool)(results[0]));
+        }
+
+        [System.Web.Services.Protocols.SoapDocumentMethodAttribute("http://smbsaas/solidcp/enterpriseserver/UpdateUserMfa", RequestNamespace = "http://smbsaas/solidcp/enterpriseserver", ResponseNamespace = "http://smbsaas/solidcp/enterpriseserver", Use = System.Web.Services.Description.SoapBindingUse.Literal, ParameterStyle = System.Web.Services.Protocols.SoapParameterStyle.Wrapped)]
         public bool UpdateUserMfa(string username, bool activate)
         {
             object[] results = this.Invoke("UpdateUserMfa", new object[] {

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Data/DataProvider.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Data/DataProvider.cs
@@ -470,6 +470,21 @@ namespace SolidCP.EnterpriseServer
                 new SqlParameter("@MfaMode", mfaMode));
         }
 
+        public static bool CanUserChangeMfa(int callerId, int changeUserId, bool canPeerChangeMfa)
+        {
+            SqlParameter prmResult = new SqlParameter("@Result", SqlDbType.Bit);
+            prmResult.Direction = ParameterDirection.Output;
+            SqlHelper.ExecuteNonQuery(ConnectionString, CommandType.StoredProcedure,
+                ObjectQualifier + "CanChangeMfa",
+                new SqlParameter("@CallerID", callerId),
+                new SqlParameter("@ChangeUserID", changeUserId),
+                new SqlParameter("@CanPeerChangeMfa", canPeerChangeMfa ? 1 : 0),
+                prmResult
+                );
+
+            return Convert.ToBoolean(prmResult.Value);
+        }
+
         #endregion
 
         #region User Settings

--- a/SolidCP/Sources/SolidCP.EnterpriseServer/esUsers.asmx.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer/esUsers.asmx.cs
@@ -288,6 +288,12 @@ namespace SolidCP.EnterpriseServer
         }
 
         [WebMethod]
+        public bool CanUserChangeMfa(int changeUserId)
+        {
+            return UserController.CanUserChangeMfa(changeUserId);
+        }
+
+        [WebMethod]
         public string[] GetUserMfaQrCodeData(string username)
         {
             return UserController.GetUserMfaQrCodeData(username);

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
@@ -6793,16 +6793,16 @@
     <value>Aktivierung nicht erfolgreich</value>
   </data>
   <data name="Error.WrongPin" xml:space="preserve">
-    <value>Falscher PIN</value>
+    <value>Falscher Bestätigungscode</value>
   </data>
   <data name="Success.PinSend" xml:space="preserve">
-    <value>PIN erfolgreich gesendet</value>
+    <value>Bestätigungscode erfolgreich gesendet</value>
   </data>
   <data name="Success.QRCodeActivation" xml:space="preserve">
     <value>Aktivierung erfolgreich</value>
   </data>
   <data name="SuccessDescription.PinSend" xml:space="preserve">
-    <value>PIN wurde erfolgreich zur primären E-Mail-Adresse gesendet.</value>
+    <value>Bestätigungscode wurde erfolgreich zur primären E-Mail-Adresse gesendet.</value>
   </data>
   <data name="TaskActivity.VPS_CREATE_TRY_JOB_COMPLETE_ATTEMPTS_LEFT_AFTER_THREAD_ABORT" xml:space="preserve">
     <value>Attempting to finish a job after a thread interruption. Remaining attempts: {0}</value>

--- a/SolidCP/Sources/SolidCP.WebPortal/Code/PortalUtils.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/Code/PortalUtils.cs
@@ -430,6 +430,15 @@ namespace SolidCP.Portal
             return FormsAuthentication.Encrypt(ticket);
         }
 
+        public static int GetUserMfaMode(string username, string password, string ipAddress)
+        {
+            esAuthentication authService = new esAuthentication();
+            ConfigureEnterpriseServerProxy(authService, false);
+            UserInfo user = authService.GetUserByUsernamePassword(username, SHA1(password), ipAddress);
+           
+            return user.MfaMode;
+        }
+
         public static void SetTicketAndCompleteLogin(string encryptedTicket, string username, bool rememberLogin, string preferredLocale, string theme)
         {
             var ticket = FormsAuthentication.Decrypt(encryptedTicket);

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/Login.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/Login.ascx.de-DE.resx
@@ -151,6 +151,6 @@
     <value>um Ihr Passwort zurückzusetzen</value>
   </data>
   <data name="btResendPin.Text" xml:space="preserve">
-    <value>PIN erneut senden</value>
+    <value>Bestätigungscode erneut senden</value>
   </data>
 </root>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/SystemSettings.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/App_LocalResources/SystemSettings.ascx.resx
@@ -133,6 +133,10 @@
     <value>PORTAL IP ADDRESS RESTRICTION SETTINGS</value>
     <comment>PORTAL IP ADDRESS RESTRICTION SETTINGS HEADER Lang = English</comment>
   </data>
+  <data name="HeaderAuthenticationSettings.Text" xml:space="preserve">
+    <value>PORTAL AUTHENTICATION SETTINGS</value>
+    <comment>PORTAL AUTHENTICATION SETTINGS HEADER Lang = English</comment>
+  </data>
   <data name="HeaderNew.Text" xml:space="preserve">
     <value>SPARE</value>
     <comment>SPARE Header</comment>
@@ -195,6 +199,14 @@
   </data>
   <data name="SettinglblIpAddressRestriction.Text" xml:space="preserve">
     <value>IP Addresses:</value>
+    <comment>Label Text</comment>
+  </data>
+  <data name="SettingtxtMfaTokenAppDisplayName.Text" xml:space="preserve">
+    <value>Authenticator Display Name:</value>
+    <comment>Label Text</comment>
+  </data>
+  <data name="SettingchkCanPeerChangeMFa.Text" xml:space="preserve">
+    <value>Can Peer Change Mfa</value>
     <comment>Label Text</comment>
   </data>
   <data name="SettinglblOwaUrl.Text" xml:space="preserve">

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/LoggedUserEditDetails.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/LoggedUserEditDetails.ascx.cs
@@ -121,7 +121,9 @@ namespace SolidCP.Portal
                 lblUsername.Text = user.Username;
                 ddlMailFormat.SelectedIndex = user.HtmlMail ? 1 : 0;
                 cbxMfaEnabled.Checked = user.MfaMode > 0 ? true : false;
+                cbxMfaEnabled.Enabled = ES.Services.Users.CanUserChangeMfa(PanelSecurity.LoggedUserId);
                 btnGetQRCodeData.Visible = cbxMfaEnabled.Checked;
+                lblMfaEnabled.Visible = cbxMfaEnabled.Checked;
 
                 // contact info
                 contact.CompanyName = user.CompanyName;
@@ -321,9 +323,10 @@ namespace SolidCP.Portal
         protected void cbxMfaEnabled_CheckedChanged(object sender, EventArgs e)
         {
             UserInfo user = ES.Services.Users.GetUserById(PanelSecurity.LoggedUserId);
-            PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
+            var result = PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
             qrData.Visible = false;
-            btnGetQRCodeData.Visible = cbxMfaEnabled.Checked;
+            btnGetQRCodeData.Visible = result;
+            lblMfaEnabled.Visible = result;
         }
 
         private void SetCurrentLanguage()

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx
@@ -52,7 +52,7 @@
             <CPCC:StyleButton ID="StyleButton2" runat="server" CssClass="btn btn-success pull-right" OnClick="btnVerifyPin_Click">
                 <asp:Localize runat="server" meta:resourcekey="btnLogin" />&nbsp;<i class="fa fa-sign-in" aria-hidden="true"></i>
             </CPCC:StyleButton>
-            <CPCC:StyleButton runat="server" id="StyleButton1" CssClass="btn btn-succsess" OnClick="btnResendPin_Click">
+            <CPCC:StyleButton runat="server" id="btnResendPin" CssClass="btn btn-succsess" OnClick="btnResendPin_Click">
                 <asp:Localize runat="server" meta:resourcekey="btResendPin" />
             </CPCC:StyleButton>
         </div>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx.cs
@@ -227,9 +227,12 @@ namespace SolidCP.Portal
 
             if (loginStatus == BusinessSuccessCodes.SUCCESS_USER_MFA_ACTIVE)
             {
+                int mfaMode = PortalUtils.GetUserMfaMode(username, password, ipAddress);
+                btnResendPin.Visible = mfaMode != 2;
                 userPwdDiv.Visible = false;
                 tokenDiv.Visible = true;
                 tokenDiv.Attributes["value"] = encryptedTicket;
+                txtPin.Focus();
                 return;
             }
 
@@ -458,7 +461,9 @@ namespace SolidCP.Portal
 
         protected void btnResendPin_Click(object sender, EventArgs e)
         {
-            if (PortalUtils.SendPin(txtUsername.Text.Trim()) == 0)
+            int sendPinResult = PortalUtils.SendPin(txtUsername.Text.Trim());
+            
+            if(sendPinResult == 0)
                 ShowSuccessMessage("PinSend");
             else
                 ShowErrorMessage("PinSendError");

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx.designer.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/Login.ascx.designer.cs
@@ -132,15 +132,6 @@ namespace SolidCP.Portal
         protected global::System.Web.UI.WebControls.TextBox txtPin;
 
         /// <summary>
-        /// StyleButton1 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::CPCC.StyleButton StyleButton1;
-
-        /// <summary>
         /// StyleButton2 control.
         /// </summary>
         /// <remarks>
@@ -148,6 +139,15 @@ namespace SolidCP.Portal
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton2;
+
+        /// <summary>
+        /// btnResendPin control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::CPCC.StyleButton btnResendPin;
 
         /// <summary>
         /// lblLanguage control.

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/PeersEditPeer.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/PeersEditPeer.ascx.cs
@@ -124,6 +124,9 @@ namespace SolidCP.Portal
                 lblUsername.Text = user.Username;
                 chkDemo.Checked = user.IsDemo;
                 cbxMfaEnabled.Checked = user.MfaMode > 0 ? true : false;
+                cbxMfaEnabled.Enabled = ES.Services.Users.CanUserChangeMfa(PanelRequest.PeerID);
+                lblMfaEnabled.Visible = cbxMfaEnabled.Checked;
+
 
                 if (user.RoleId == (int)UserRole.ResellerCSR) role.SelectedIndex = 0;
                 if (user.RoleId == (int)UserRole.PlatformCSR) role.SelectedIndex = 0;
@@ -360,8 +363,10 @@ namespace SolidCP.Portal
 
         protected void cbxMfaEnabled_CheckedChanged(object sender, EventArgs e)
         {
-            UserInfo user = ES.Services.Users.GetUserById(PanelSecurity.SelectedUserId);
-            PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
+            UserInfo user = ES.Services.Users.GetUserById(PanelRequest.PeerID);
+            bool result = PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
+            lblMfaEnabled.Visible = result;
+            cbxMfaEnabled.Checked = result;
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SkinControls/SignedInUser.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SkinControls/SignedInUser.ascx.cs
@@ -64,7 +64,7 @@ namespace SolidCP.Portal.SkinControls
                // lnkEditUserDetails.Text = PanelSecurity.LoggedUser.Username;
                 lnkEditUserDetails.NavigateUrl = PortalUtils.GetLoggedUserAccountPageUrl();
                 lnkEditUserDetailsSm.NavigateUrl = PortalUtils.GetLoggedUserAccountPageUrl();
-
+                lnkEditUserDetails.Text = user.Username;
             }
 
 			AnonymousPanel.Visible = !Request.IsAuthenticated;

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx
@@ -430,5 +430,45 @@
                 </div>
             </div>
         </div>
+        <div class="panel panel-default">
+            <div class="panel-heading panel-heading-link">
+                <span><i class="fa fa-lock" aria-hidden="true">&nbsp;</i>&nbsp;&nbsp;</span>
+                <a data-toggle="collapse" data-parent="#accordion" href="#AuthenticationSettings" aria-expanded="false" class="collapsed">
+                    <asp:Localize ID="HeaderAuthenticationSettings" runat="server" meta:resourcekey="HeaderAuthenticationSettings" /><span class='fa fa-plus pull-right' aria-hidden='true'> </span>
+                </a>
+            </div>
+            <div id="AuthenticationSettings" class="panel-collapse collapse" aria-expanded="false" style="height: 0px;">
+                <div class="panel-body">
+                    <fieldset>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <CPCC:H5Label runat="server" for="txtMfaTokenAppDisplayName" class="col-sm-2 control-label">
+                                                <asp:Localize ID="SettingtxtMfaTokenAppDisplayName" runat="server" meta:resourcekey="SettingtxtMfaTokenAppDisplayName" />
+                                    </CPCC:H5Label>
+                                    <div class="col-sm-6">
+                                        <asp:TextBox runat="server" Rows="10" ID="txtMfaTokenAppDisplayName" CssClass="form-control" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <CPCC:H5Label runat="server" for="chkCanPeerChangeMFa" class="col-sm-2 control-label">
+                                        <asp:Localize ID="SettingchkCanPeerChangeMFa" runat="server" meta:resourcekey="SettingchkCanPeerChangeMFa" />
+                                    </CPCC:H5Label>
+                                <div class="col-sm-6">
+                                    <asp:CheckBox ID="chkCanPeerChangeMFa" runat="server" CssClass="form-control" Text="Yes" meta:resourcekey="SettingchkCanPeerChangeMFa" />
+                                </div>
+                            </div>
+                        </div>
+                        </div>
+                    </fieldset>
+                    <hr />
+                    <CPCC:StyleButton ID="btnAuthenticationSettings" CssClass="btn btn-success btn-block" runat="server" meta:resourcekey="SettingbtnSaveSettings" OnClick="btnAuthenticationSettings_Click" />
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx.cs
@@ -195,6 +195,15 @@ namespace SolidCP.Portal
             {
                 txtIPAddress.Text = settings.GetValueOrDefault(SCP.SystemSettings.ACCESS_IPs, string.Empty);
             }
+
+            // Authenitcation settings
+            settings = ES.Services.System.GetSystemSettings(SCP.SystemSettings.AUTHENTICATION_SETTINGS);
+
+            if (settings != null)
+            {
+                txtMfaTokenAppDisplayName.Text = settings.GetValueOrDefault(SCP.SystemSettings.MFA_TOKEN_APP_DISPLAY_NAME, string.Empty);
+                chkCanPeerChangeMFa.Checked = settings.GetValueOrDefault(SCP.SystemSettings.MFA_CAN_PEER_CHANGE_MFA, true);
+            }
         }
         private void SaveSMTP()
         {
@@ -449,7 +458,36 @@ namespace SolidCP.Portal
 
             ShowSuccessMessage("SYSTEM_SETTINGS_SAVE");
         }
-        
+
+        private void SaveAuthentication()
+        {
+            try
+            {
+                SCP.SystemSettings settings = new SCP.SystemSettings();
+
+                // authentication settings
+                settings = new SCP.SystemSettings();
+                settings[SCP.SystemSettings.MFA_TOKEN_APP_DISPLAY_NAME] = txtMfaTokenAppDisplayName.Text.Trim();
+                settings[SCP.SystemSettings.MFA_CAN_PEER_CHANGE_MFA] = chkCanPeerChangeMFa.Checked ? "True" : "False";
+
+
+                int result = ES.Services.System.SetSystemSettings(SCP.SystemSettings.AUTHENTICATION_SETTINGS, settings);
+
+                if (result < 0)
+                {
+                    ShowResultMessage(result);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                ShowErrorMessage("SYSTEM_SETTINGS_SAVE", ex);
+                return;
+            }
+
+            ShowSuccessMessage("SYSTEM_SETTINGS_SAVE");
+        }
+
         #region Button Calls
         protected void btnSaveSMTP_Click(object sender, EventArgs e)
         {
@@ -490,6 +528,11 @@ namespace SolidCP.Portal
         protected void btnSaveRESTRICT_Click(object sender, EventArgs e)
         {
             SaveRESTRICT();
+        }
+
+        protected void btnAuthenticationSettings_Click(object sender, EventArgs e)
+        {
+            SaveAuthentication();
         }
         #endregion
     }

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx.designer.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/SystemSettings.ascx.designer.cs
@@ -7,11 +7,13 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace SolidCP.Portal {
-    
-    
-    public partial class SystemSettings {
-        
+namespace SolidCP.Portal
+{
+
+
+    public partial class SystemSettings
+    {
+
         /// <summary>
         /// SettinglblSmtpServer control.
         /// </summary>
@@ -20,7 +22,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblSmtpServer;
-        
+
         /// <summary>
         /// txtSmtpServer control.
         /// </summary>
@@ -29,7 +31,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSmtpServer;
-        
+
         /// <summary>
         /// SettinglblSmtpPort control.
         /// </summary>
@@ -38,7 +40,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblSmtpPort;
-        
+
         /// <summary>
         /// txtSmtpPort control.
         /// </summary>
@@ -47,7 +49,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSmtpPort;
-        
+
         /// <summary>
         /// SettinglblSmtpUser control.
         /// </summary>
@@ -56,7 +58,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblSmtpUser;
-        
+
         /// <summary>
         /// txtSmtpUser control.
         /// </summary>
@@ -65,7 +67,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSmtpUser;
-        
+
         /// <summary>
         /// SettinglblSmtpUserPassword control.
         /// </summary>
@@ -74,7 +76,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblSmtpUserPassword;
-        
+
         /// <summary>
         /// txtSmtpPassword control.
         /// </summary>
@@ -83,7 +85,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSmtpPassword;
-        
+
         /// <summary>
         /// SettinglblSmtpEnableSSL control.
         /// </summary>
@@ -92,7 +94,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblSmtpEnableSSL;
-        
+
         /// <summary>
         /// chkEnableSsl control.
         /// </summary>
@@ -101,7 +103,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkEnableSsl;
-        
+
         /// <summary>
         /// configuremailtemplates control.
         /// </summary>
@@ -110,7 +112,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize configuremailtemplates;
-        
+
         /// <summary>
         /// MailTemplates control.
         /// </summary>
@@ -119,7 +121,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink MailTemplates;
-        
+
         /// <summary>
         /// StyleButton1 control.
         /// </summary>
@@ -128,7 +130,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton1;
-        
+
         /// <summary>
         /// SettinglblBackupFolderPath control.
         /// </summary>
@@ -137,7 +139,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblBackupFolderPath;
-        
+
         /// <summary>
         /// txtBackupsPath control.
         /// </summary>
@@ -146,7 +148,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtBackupsPath;
-        
+
         /// <summary>
         /// StyleButton2 control.
         /// </summary>
@@ -155,7 +157,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton2;
-        
+
         /// <summary>
         /// SettinglblWpiMainFeedUrl control.
         /// </summary>
@@ -164,7 +166,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblWpiMainFeedUrl;
-        
+
         /// <summary>
         /// txtMainFeedUrl control.
         /// </summary>
@@ -173,7 +175,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMainFeedUrl;
-        
+
         /// <summary>
         /// SettingBtnWpiAddCustomFeeds control.
         /// </summary>
@@ -182,7 +184,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettingBtnWpiAddCustomFeeds;
-        
+
         /// <summary>
         /// wpiEditFeedsList control.
         /// </summary>
@@ -191,7 +193,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::SolidCP.Portal.UserControls.EditFeedsList wpiEditFeedsList;
-        
+
         /// <summary>
         /// StyleButton3 control.
         /// </summary>
@@ -200,7 +202,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton3;
-        
+
         /// <summary>
         /// SettinglblFileManagerEditableExtensions control.
         /// </summary>
@@ -209,7 +211,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblFileManagerEditableExtensions;
-        
+
         /// <summary>
         /// txtFileManagerEditableExtensions control.
         /// </summary>
@@ -218,7 +220,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtFileManagerEditableExtensions;
-        
+
         /// <summary>
         /// SettinglitFileManagerEditableExtensions control.
         /// </summary>
@@ -227,7 +229,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Literal SettinglitFileManagerEditableExtensions;
-        
+
         /// <summary>
         /// StyleButton4 control.
         /// </summary>
@@ -236,7 +238,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton4;
-        
+
         /// <summary>
         /// SettinglblRdsController control.
         /// </summary>
@@ -245,7 +247,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblRdsController;
-        
+
         /// <summary>
         /// ddlRdsController control.
         /// </summary>
@@ -254,7 +256,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlRdsController;
-        
+
         /// <summary>
         /// StyleButton5 control.
         /// </summary>
@@ -263,7 +265,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton5;
-        
+
         /// <summary>
         /// SettinglblEnableOwa control.
         /// </summary>
@@ -272,7 +274,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblEnableOwa;
-        
+
         /// <summary>
         /// chkEnableOwa control.
         /// </summary>
@@ -281,7 +283,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkEnableOwa;
-        
+
         /// <summary>
         /// SettinglblOwaUrl control.
         /// </summary>
@@ -290,7 +292,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblOwaUrl;
-        
+
         /// <summary>
         /// txtOwaUrl control.
         /// </summary>
@@ -299,7 +301,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtOwaUrl;
-        
+
         /// <summary>
         /// StyleButton6 control.
         /// </summary>
@@ -308,7 +310,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton6;
-        
+
         /// <summary>
         /// SettinglblTwilioAccountSid control.
         /// </summary>
@@ -317,7 +319,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblTwilioAccountSid;
-        
+
         /// <summary>
         /// txtAccountSid control.
         /// </summary>
@@ -326,7 +328,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtAccountSid;
-        
+
         /// <summary>
         /// SettinglblTwilioAuthToken control.
         /// </summary>
@@ -335,7 +337,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblTwilioAuthToken;
-        
+
         /// <summary>
         /// txtAuthToken control.
         /// </summary>
@@ -344,7 +346,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtAuthToken;
-        
+
         /// <summary>
         /// SettinglblTwilioPhoneFrom control.
         /// </summary>
@@ -353,7 +355,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblTwilioPhoneFrom;
-        
+
         /// <summary>
         /// txtPhoneFrom control.
         /// </summary>
@@ -362,7 +364,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtPhoneFrom;
-        
+
         /// <summary>
         /// SettingNoteTwilioAccount control.
         /// </summary>
@@ -371,7 +373,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettingNoteTwilioAccount;
-        
+
         /// <summary>
         /// btnTwilioDisable control.
         /// </summary>
@@ -380,7 +382,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton btnTwilioDisable;
-        
+
         /// <summary>
         /// StyleButton7 control.
         /// </summary>
@@ -389,7 +391,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton7;
-        
+
         /// <summary>
         /// SettinglblEnablePasswordReset control.
         /// </summary>
@@ -398,7 +400,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblEnablePasswordReset;
-        
+
         /// <summary>
         /// chkEnablePasswordReset control.
         /// </summary>
@@ -407,7 +409,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkEnablePasswordReset;
-        
+
         /// <summary>
         /// SettinglblPasswordResetLinkLifeSpan control.
         /// </summary>
@@ -416,7 +418,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblPasswordResetLinkLifeSpan;
-        
+
         /// <summary>
         /// txtPasswordResetLinkLifeSpan control.
         /// </summary>
@@ -425,7 +427,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtPasswordResetLinkLifeSpan;
-        
+
         /// <summary>
         /// SettingNotePasswordResetLinkLifeSpan control.
         /// </summary>
@@ -434,7 +436,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettingNotePasswordResetLinkLifeSpan;
-        
+
         /// <summary>
         /// SettinglblWebdavPortalUrl control.
         /// </summary>
@@ -443,7 +445,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblWebdavPortalUrl;
-        
+
         /// <summary>
         /// txtWebdavPortalUrl control.
         /// </summary>
@@ -452,7 +454,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtWebdavPortalUrl;
-        
+
         /// <summary>
         /// StyleButton8 control.
         /// </summary>
@@ -461,7 +463,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton8;
-        
+
         /// <summary>
         /// HeaderIpRestrictionSettings control.
         /// </summary>
@@ -470,7 +472,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize HeaderIpRestrictionSettings;
-        
+
         /// <summary>
         /// SettinglblIpAddressRestriction control.
         /// </summary>
@@ -479,7 +481,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Localize SettinglblIpAddressRestriction;
-        
+
         /// <summary>
         /// txtIPAddress control.
         /// </summary>
@@ -488,7 +490,7 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtIPAddress;
-        
+
         /// <summary>
         /// StyleButton9 control.
         /// </summary>
@@ -497,5 +499,59 @@ namespace SolidCP.Portal {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::CPCC.StyleButton StyleButton9;
+
+        /// <summary>
+        /// HeaderAuthenticationSettings control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Localize HeaderAuthenticationSettings;
+
+        /// <summary>
+        /// SettingtxtMfaTokenAppDisplayName control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Localize SettingtxtMfaTokenAppDisplayName;
+
+        /// <summary>
+        /// txtMfaTokenAppDisplayName control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtMfaTokenAppDisplayName;
+
+        /// <summary>
+        /// SettingchkCanPeerChangeMFa control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Localize SettingchkCanPeerChangeMFa;
+
+        /// <summary>
+        /// chkCanPeerChangeMFa control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBox chkCanPeerChangeMFa;
+
+        /// <summary>
+        /// btnAuthenticationSettings control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::CPCC.StyleButton btnAuthenticationSettings;
     }
 }

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/UserAccountEditDetails.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/UserAccountEditDetails.ascx.cs
@@ -92,6 +92,8 @@ namespace SolidCP.Portal
                     ddlMailFormat.SelectedIndex = user.HtmlMail ? 1 : 0;
                     lblUsername.Text = user.Username;
                     cbxMfaEnabled.Checked = user.MfaMode > 0 ? true: false;
+                    cbxMfaEnabled.Enabled = ES.Services.Users.CanUserChangeMfa(PanelSecurity.SelectedUserId);
+                    lblMfaEnabled.Visible = cbxMfaEnabled.Checked;
 
                     // contact info
                     contact.CompanyName = user.CompanyName;
@@ -218,7 +220,9 @@ namespace SolidCP.Portal
         protected void cbxMfaEnabled_CheckedChanged(object sender, EventArgs e)
         {
             UserInfo user = ES.Services.Users.GetUserById(PanelSecurity.SelectedUserId);
-            PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
+            bool result = PortalUtils.UpdateUserMfa(user.Username, cbxMfaEnabled.Checked);
+            lblMfaEnabled.Visible = result;
+            cbxMfaEnabled.Checked = result;
         }
     }
 }


### PR DESCRIPTION
The following enhancements / fixes have been implemented:
1. If the user generates the confirmation code via the app, an e-mail is no longer sent. It is also not possible to send it again during login.
2. If a user does not have the "right" to change MFA Mode, the checkbox is deactivated.
3. In the system settings, it is possible to prohibit peer logins from changing their MFA mode.
4. In the system settings, it is possible to change the display name used in the authenticator app. The default is SolidCP.
5. In the upper right corner the username of the currently logged in user is displayed.