### PR TITLE
Send password reset request for existing users

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationUserGeneralSettings.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationUserGeneralSettings.ascx.cs
@@ -384,6 +384,14 @@ namespace SolidCP.Portal.HostedSolution
 
                 imgVipUser.Visible = chkVIP.Checked && secServiceLevels.Visible;
 
+                if (sendToControl.SendEmail)
+                {
+                    ES.Services.Organizations.SendUserPasswordRequestEmail(PanelRequest.ItemID, PanelRequest.AccountID, "Change user settings", sendToControl.Email, true);
+                }
+                else if (sendToControl.SendMobile)
+                {
+                    ES.Services.Organizations.SendUserPasswordRequestSms(PanelRequest.ItemID, PanelRequest.AccountID, "Change user settings", sendToControl.Mobile);
+                }
 
                 messageBox.ShowSuccessMessage("ORGANIZATION_UPDATE_USER_SETTINGS");
             }


### PR DESCRIPTION
# Description

Send password reset request for existing users

Fixes # (issue)

If you enable the password reset Link in System Settings -> Cloud storage portal settings, you can send a password reset email for a new users. However, this didn't work for existing users.