### PR TITLE
[WebDavPortal] Fix "Please wait" dialog hang up

### DIFF
--- a/SolidCP/Sources/SolidCP.WebDavPortal/Scripts/appScripts/SCP-webdav.js
+++ b/SolidCP/Sources/SolidCP.WebDavPortal/Scripts/appScripts/SCP-webdav.js
@@ -36,6 +36,9 @@ $(document).on('dblclick', '.element-container', function (e) {
     }
 });
 
+window.addEventListener("pageshow", function (event) {
+    scp.dialogs.hideProcessDialog();
+});
 
 //Delete button click
 $(document).on('click', '.file-deletion #delete-button', function (e) {


### PR DESCRIPTION
# Description

[WebDavPortal] Fix "Please wait" dialog hang up if browser page back button pressed

Fixes # (issue)

Sometimes the "Please wait..." modal hangs when you go into a folder and then press the back button in the browser.