### PR TITLE
New quota added - Disable Tenant To Remove Top-Level Domain

### DIFF
--- a/Languages/Arabic/Resources.xml
+++ b/Languages/Arabic/Resources.xml
@@ -5647,9 +5647,15 @@
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
-    <Key>Quota.OS.AllowTenantCreateDomains</Key>
+    <Key>Quota.OS.NotAllowTenantCreateDomains</Key>
     <DefaultValue>Disable Tenant To Create Top-Level Domain</DefaultValue>
     <Value>تعطيل المستأجر لإنشاء نطاق المستوى الأعلى</Value>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>Quota.OS.NotAllowTenantDeleteDomains</Key>
+    <DefaultValue>Disable Tenant To Remove Top-Level Domain</DefaultValue>
+    <Value>تعطيل المستأجر لحذف مجال المستوى الأعلى</Value>
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>

--- a/Languages/German/Resources.xml
+++ b/Languages/German/Resources.xml
@@ -5480,9 +5480,15 @@
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
-    <Key>Quota.OS.AllowTenantCreateDomains</Key>
+    <Key>Quota.OS.NotAllowTenantCreateDomains</Key>
     <DefaultValue>Disable Tenant To Create Top-Level Domain</DefaultValue>
     <Value>Mandant darf keine Top-Level Domains erstellen.</Value>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>Quota.OS.NotAllowTenantDeleteDomains</Key>
+    <DefaultValue>Disable Tenant To Remove Top-Level Domain</DefaultValue>
+    <Value>Mandant darf keine Top-Level Domains löschen.</Value>
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>

--- a/Languages/Resources.xml
+++ b/Languages/Resources.xml
@@ -4717,8 +4717,13 @@
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
-    <Key>Quota.OS.AllowTenantCreateDomains</Key>
+    <Key>Quota.OS.NotAllowTenantCreateDomains</Key>
     <DefaultValue>Disable Tenant To Create Top-Level Domain</DefaultValue>
+  </Resource>
+  <Resource>
+    <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>
+    <Key>Quota.OS.NotAllowTenantDeleteDomains</Key>
+    <DefaultValue>Disable Tenant To Remove Top-Level Domain</DefaultValue>
   </Resource>
   <Resource>
     <File>App_GlobalResources\SolidCP_SharedResources.ascx.resx</File>

--- a/SolidCP/Database/update_db.sql
+++ b/SolidCP/Database/update_db.sql
@@ -19803,3 +19803,10 @@ AS
 	SET @Result = dbo.CanChangeMfaFunc(@CallerID, @ChangeUserID, @CanPeerChangeMfa)
 	RETURN
 GO
+
+IF NOT EXISTS (SELECT * FROM [dbo].[Quotas] WHERE [QuotaID] = 409)
+BEGIN
+	INSERT [dbo].[Quotas] ([QuotaID], [GroupID], [QuotaOrder], [QuotaName], [QuotaDescription], [QuotaTypeID], [ServiceQuota], [ItemTypeID], [HideQuota]) VALUES (409, 1, 13, N'OS.NotAllowTenantDeleteDomains', N'Not allow Tenants to Delete Top Level Domains', 1, 0, NULL, NULL)
+	UPDATE [dbo].[Quotas] SET [QuotaName] = N'OS.NotAllowTenantCreateDomains', [QuotaDescription] = N'Not allow Tenants to Create Top Level Domains' WHERE [QuotaID] = 410
+END
+GO

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Base/Packages/Quotas.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Base/Packages/Quotas.cs
@@ -54,8 +54,9 @@ order by rg.groupOrder
 		public const string OS_MINIMUMTASKINTERVAL = "OS.MinimumTaskInterval";  // Minimum Tasks Interval, minutes
 		public const string OS_APPINSTALLER = "OS.AppInstaller";  // Applications Installer
 		public const string OS_EXTRAAPPLICATIONS = "OS.ExtraApplications";  // Extra Application Packs
-        public const string OS_NOTALLOWTENANTCREATEDOMAINS = "OS.AllowTenantCreateDomains";  // Do not Allow tenant to create top level domains
-		public const string WEB_SITES = "Web.Sites";  // Web Sites
+        public const string OS_NOTALLOWTENANTCREATEDOMAINS = "OS.NotAllowTenantCreateDomains";  // Do not Allow tenant to create top level domains
+        public const string OS_NOTALLOWTENANTDELETEDOMAINS = "OS.NotAllowTenantDeleteDomains";  // Do not Allow tenant to delete top level domains
+        public const string WEB_SITES = "Web.Sites";  // Web Sites
 		public const string WEB_ASPNET11 = "Web.AspNet11";  // ASP.NET 1.1
 		public const string WEB_ASPNET20 = "Web.AspNet20";  // ASP.NET 2.0
 		public const string WEB_ASPNET40 = "Web.AspNet40";  // ASP.NET 4.0

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
@@ -1656,8 +1656,11 @@
   <data name="Quota.OS.FileManager" xml:space="preserve">
     <value>مدير الملفات</value>
   </data>
-  <data name="Quota.OS.AllowTenantCreateDomains" xml:space="preserve">
+  <data name="Quota.OS.NotAllowTenantCreateDomains" xml:space="preserve">
     <value>تعطيل المستأجر لإنشاء نطاق المستوى الأعلى</value>
+  </data>
+  <data name="Quota.OS.NotAllowTenantDeleteDomains" xml:space="preserve">
+    <value>تعطيل المستأجر لحذف مجال المستوى الأعلى</value>
   </data>
   <data name="Quota.SharePoint.Groups" xml:space="preserve">
     <value>مجموعات شيربوينت</value>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
@@ -1656,8 +1656,11 @@
   <data name="Quota.OS.FileManager" xml:space="preserve">
     <value>Dateimanager</value>
   </data>
-  <data name="Quota.OS.AllowTenantCreateDomains" xml:space="preserve">
+  <data name="Quota.OS.NotAllowTenantCreateDomains" xml:space="preserve">
     <value>Mandant darf keine Top-Level Domains erstellen.</value>
+  </data>
+  <data name="Quota.OS.NotAllowTenantDeleteDomains" xml:space="preserve">
+    <value>Mandant darf keine Top-Level Domains löschen.</value>
   </data>
   <data name="Quota.SharePoint.Groups" xml:space="preserve">
     <value>SharePoint-Gruppen</value>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
@@ -1656,8 +1656,11 @@
   <data name="Quota.OS.FileManager" xml:space="preserve">
     <value>File Manager</value>
   </data>
-  <data name="Quota.OS.AllowTenantCreateDomains" xml:space="preserve">
+  <data name="Quota.OS.NotAllowTenantCreateDomains" xml:space="preserve">
     <value>Disable Tenant To Create Top-Level Domain</value>
+  </data>
+  <data name="Quota.OS.NotAllowTenantDeleteDomains" xml:space="preserve">
+    <value>Disable Tenant To Remove Top-Level Domain</value>
   </data>
   <data name="Quota.SharePoint.Groups" xml:space="preserve">
     <value>SharePoint Groups</value>

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/DomainsEditDomain.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/DomainsEditDomain.ascx.cs
@@ -180,7 +180,7 @@ namespace SolidCP.Portal
                     {
                         if (user.Role == UserRole.User)
                         {
-                            btnDelete.Enabled = !Utils.CheckQouta(Quotas.OS_NOTALLOWTENANTCREATEDOMAINS, cntx);
+                            btnDelete.Enabled = !Utils.CheckQouta(Quotas.OS_NOTALLOWTENANTDELETEDOMAINS, cntx);
                         }
                     }
                 }


### PR DESCRIPTION
# Description

- New quota added - Disable Tenant To Remove Top-Level Domain
- Check not allow create/remove domain quotas on ES

You can now use separate settings to deny users from creating or removing TLDs:
Hosting Plan -> System -> Disable Tenant To Create Top-Level Domain and Disable Tenant To Remove Top-Level Domain