### PR TITLE
[HyperV2012R2+] Check the VM RAM >= 32

### DIFF
--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Base/Virtualization/VirtualizationErrorCodes.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Base/Virtualization/VirtualizationErrorCodes.cs
@@ -44,6 +44,7 @@
         public const string QUOTA_EXCEEDED_CPU = "VPS_QUOTA_EXCEEDED_CPU";
         public const string QUOTA_EXCEEDED_RAM = "VPS_QUOTA_EXCEEDED_RAM";
         public const string QUOTA_WRONG_RAM = "VPS_QUOTA_WRONG_RAM";
+        public const string QUOTA_WRONG_RAM_HV = "VPS_QUOTA_WRONG_RAM_HV";
         public const string QUOTA_NOT_IN_DYNAMIC_RAM = "VPS_QUOTA_NOT_IN_DYNAMIC_RAM";
         public const string QUOTA_EXCEEDED_HDD = "VPS_QUOTA_EXCEEDED_HDD";
         public const string QUOTA_EXCEEDED_HDDS = "VPS_QUOTA_EXCEEDED_HDDS";

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization/VirtualizationServerController.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization/VirtualizationServerController.cs
@@ -417,8 +417,8 @@ namespace SolidCP.EnterpriseServer
                 }
 
                 // check acceptable values
-                if (ramMB <= 0)
-                    quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM);
+                if (ramMB < 32)
+                    quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM_HV);
                 if (hddGB <= 0)
                     quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_HDD);
                 if (snapshots < 0)

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/CreateVirtualMachineHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/CreateVirtualMachineHandler.cs
@@ -133,8 +133,8 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
                 }
 
                 // check acceptable values
-                if (VMSettings.RamSize <= 0)
-                    quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM);
+                if (VMSettings.RamSize < 32)
+                    quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM_HV);
 
                 if (VMSettings.HddSize.Length == 0) //if we pass the empty array of HddSize it broke everything.
                     quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_HDD);

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ImportVirtualMachineHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/ImportVirtualMachineHandler.cs
@@ -174,8 +174,8 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
                     QuotaHelper.CheckBooleanQuota(cntx, quotaResults, Quotas.VPS2012_PRIVATE_NETWORK_ENABLED, item.PrivateNetworkEnabled, VirtualizationErrorCodes.QUOTA_EXCEEDED_PRIVATE_NETWORK_ENABLED);
 
                     // check acceptable values
-                    if (item.RamSize <= 0)
-                        quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM);
+                    if (item.RamSize < 32)
+                        quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM_HV);
                     foreach (var hddSize in item.HddSize)
                     {
                         if (hddSize <= 0)

--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineResourceHandler.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/UseCase/UpdateVirtualMachineResourceHandler.cs
@@ -95,8 +95,8 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.UseCase
             QuotaHelper.CheckBooleanQuota(cntx, quotaResults, Quotas.VPS2012_DMZ_NETWORK_ENABLED, vmSettings.DmzNetworkEnabled, VirtualizationErrorCodes.QUOTA_EXCEEDED_DMZ_NETWORK_ENABLED);
 
             // check acceptable values
-            if (vmSettings.RamSize <= 0)
-                quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM);
+            if (vmSettings.RamSize < 32)
+                quotaResults.Add(VirtualizationErrorCodes.QUOTA_WRONG_RAM_HV);
             foreach (var hddSize in vmSettings.HddSize)
             {
                 if (hddSize <= 0)

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.ar-AE.resx
@@ -4830,6 +4830,9 @@
   <data name="VPS.VPS_QUOTA_WRONG_RAM" xml:space="preserve">
     <value>يجب أن يكون حجم ذاكرة الوصول العشوائي رقمًا موجبًا وأكبر من الصفر</value>
   </data>
+  <data name="VPS.VPS_QUOTA_WRONG_RAM_HV" xml:space="preserve">
+    <value>يجب أن يكون حجم ذاكرة الوصول العشوائي أكبر من 32 ميجابايت</value>
+  </data>
   <data name="VPS.VPS_QUOTA_NOT_IN_DYNAMIC_RAM" xml:space="preserve">
     <value>يجب أن يكون حجم ذاكرة الوصول العشوائي بين الحد الأدنى والحد الأقصى للذاكرة الديناميكية</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.de-DE.resx
@@ -4899,6 +4899,9 @@
   <data name="VPS.VPS_QUOTA_WRONG_RAM" xml:space="preserve">
     <value>RAM-Größe muß eine postitive Zahl und größer als Null sein.</value>
   </data>
+  <data name="VPS.VPS_QUOTA_WRONG_RAM_HV" xml:space="preserve">
+    <value>RAM-Größe muss größer als 32 MB sein</value>
+  </data>
   <data name="VPS.VPS_QUOTA_NOT_IN_DYNAMIC_RAM" xml:space="preserve">
     <value>RAM-Größe muss zwischen dem Minimum und Maximum des dynamischen Speichers liegen</value>
   </data>

--- a/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
+++ b/SolidCP/Sources/SolidCP.WebPortal/App_GlobalResources/SolidCP_SharedResources.ascx.resx
@@ -4906,6 +4906,9 @@
   <data name="VPS.VPS_QUOTA_WRONG_RAM" xml:space="preserve">
     <value>RAM size must be a positive number and greater than zero</value>
   </data>
+  <data name="VPS.VPS_QUOTA_WRONG_RAM_HV" xml:space="preserve">
+    <value>RAM size must be greater than 32 MB</value>
+  </data>
   <data name="VPS.VPS_QUOTA_NOT_IN_DYNAMIC_RAM" xml:space="preserve">
     <value>RAM size must be between the minimum and maximum of the dynamic memory</value>
   </data>


### PR DESCRIPTION
# Description

 - [HyperV2012R2+] Check the VM RAM >= 32

Fixes # (issue)

If you happen to create a Hyper-V VM with less than 32MB of RAM, this will cause an error and the VM will not be assigned with the SolidCP correctly and cannot be deleted via SolidCP anymore