### PR TITLE
[Exchange] Use PortalAntiXSS.Encode for litDisplayName (fix for 96637d1)

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationUserGeneralSettings.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/OrganizationUserGeneralSettings.ascx.cs
@@ -94,7 +94,7 @@ namespace SolidCP.Portal.HostedSolution
                 OrganizationUser user = ES.Services.Organizations.GetUserGeneralSettings(PanelRequest.ItemID,
                     PanelRequest.AccountID);
 
-                litDisplayName.Text = user.DisplayName;
+                litDisplayName.Text = PortalAntiXSS.Encode(user.DisplayName);
 
                 lblUserDomainName.Text = user.DomainUserName;
 


### PR DESCRIPTION
# Description

Fix for 96637d1 - TextBox doesn't run HTML, JavaScript etc., but Literal does..