### PR TITLE
[HyperV] DMZ VLAN will be removed from DB when settings changed - fixed

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsEditConfiguration.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/VPS2012/VpsDetailsEditConfiguration.ascx.cs
@@ -290,6 +290,7 @@ namespace SolidCP.Portal.VPS2012
                 virtualMachine.NeedReboot = chkForceReboot.Checked;
                 virtualMachine.defaultaccessvlan = vm.defaultaccessvlan;
                 virtualMachine.PrivateNetworkVlan = vm.PrivateNetworkVlan;
+                virtualMachine.DmzNetworkVlan = vm.DmzNetworkVlan;
 
                 bool setupExternalNetwork = !vm.ExternalNetworkEnabled && chkExternalNetworkEnabled.Checked;
                 bool setupPrivateNetwork = !vm.PrivateNetworkEnabled && chkPrivateNetworkEnabled.Checked;


### PR DESCRIPTION
Fixes # (issue)

DMZ network VLAN could be removed from the database when some VM settings were changed