### PR TITLE
[Installer] Add partial offline installer and fix SQL update fatal error

### DIFF
--- a/SolidCP.Installer/Sources/Setup.WIX/Product.wxs
+++ b/SolidCP.Installer/Sources/Setup.WIX/Product.wxs
@@ -7,12 +7,13 @@
   <Product Id="*" Name="SolidCP Installer" Language="1033" Version="$(var.VERSION)" Manufacturer="SolidCP" UpgradeCode="629ccd5c-1f6d-4168-bbe6-01c69e232f43">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
-		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallExecute"/>
     
     <MediaTemplate EmbedCab="yes" />
      
 		<Feature Id="ProductFeature" Title="SolidCP Installer" Level="1">
       <ComponentRef Id="ProductFiles" />
+      <ComponentRef Id="ConfigFile" />
       <ComponentRef Id="ApplicationShortcut" />
 		</Feature>
 
@@ -48,10 +49,13 @@
        <Component Id="ProductFiles" Guid="A89FA6CF-53E2-4390-9E9D-11CD4297D738">
         <File Id="SolidCP.Installer.Core.dll" Source="$(var.BUILDPATH)\SolidCP.Installer.Core.dll" />
         <File Id="SolidCP.Installer.exe" Source="$(var.BUILDPATH)\SolidCP.Installer.exe" />
-        <File Id="SolidCP.Installer.exe.config" Source="$(var.BUILDPATH)\SolidCP.Installer.exe.config" />
+         <!-- <File Id="SolidCP.Installer.exe.config" Source="$(var.BUILDPATH)\SolidCP.Installer.exe.config" /> -->
         <File Id="SolidCP.SilentInstaller.exe" Source="$(var.BUILDPATH)\SolidCP.SilentInstaller.exe" />
         <File Id="DotNetZip" Source="$(var.BUILDPATH)\Ionic.Zip.Reduced.dll" />
       </Component>
+        <Component Id="ConfigFile" Guid="B12FA6CF-53E2-4390-9E9D-11CD4297D739" NeverOverwrite="yes">
+          <File Id="SolidCP.Installer.exe.config" Source="$(var.BUILDPATH)\SolidCP.Installer.exe.config" />
+        </Component>
       </DirectoryRef>
     
       <!-- Shortcut -->

--- a/SolidCP.Installer/Sources/Setup.WIXInstaller/Product.wxs
+++ b/SolidCP.Installer/Sources/Setup.WIXInstaller/Product.wxs
@@ -1049,7 +1049,7 @@
     </Fragment>
     <Fragment>
         <ComponentGroup Id="SolidCPFiles">
-            <Component Id ="comp_SolidCP_config" Directory="SCP_INSTALL_DIR" Guid="{28CD1ADB-562C-4E38-A3B6-325D3A2718B1}">
+            <Component Id ="comp_SolidCP_config" Directory="SCP_INSTALL_DIR" Guid="{28CD1ADB-562C-4E38-A3B6-325D3A2718B1}" NeverOverwrite="yes">
                 <File Id="file_SolidCP_config" KeyPath="yes" Source="SolidCP.config" />
             </Component>
             <Component Id="comp_SolidCP_reg_locator" Directory="SCP_INSTALL_DIR" Guid="{CC35E1B5-3E29-4AD1-991C-2904E4DCB099}">

--- a/SolidCP.Installer/Sources/Setup.WIXInstaller/Product.wxs
+++ b/SolidCP.Installer/Sources/Setup.WIXInstaller/Product.wxs
@@ -1049,7 +1049,7 @@
     </Fragment>
     <Fragment>
         <ComponentGroup Id="SolidCPFiles">
-            <Component Id ="comp_SolidCP_config" Directory="SCP_INSTALL_DIR" Guid="{28CD1ADB-562C-4E38-A3B6-325D3A2718B1}" NeverOverwrite="yes">
+            <Component Id ="comp_SolidCP_config" Directory="SCP_INSTALL_DIR" Guid="{28CD1ADB-562C-4E38-A3B6-325D3A2718B1}">
                 <File Id="file_SolidCP_config" KeyPath="yes" Source="SolidCP.config" />
             </Component>
             <Component Id="comp_SolidCP_reg_locator" Directory="SCP_INSTALL_DIR" Guid="{CC35E1B5-3E29-4AD1-991C-2904E4DCB099}">

--- a/SolidCP.Installer/Sources/SolidCP.Installer.Core/Common/FileUtils.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Installer.Core/Common/FileUtils.cs
@@ -258,6 +258,15 @@ namespace SolidCP.Installer.Common
         }
 
         /// <summary>
+        /// Returns application offline directory.
+        /// </summary>
+        /// <returns>Application offline directory.</returns>
+        public static string GetOfflineDataDirectory()
+        {
+            return Path.Combine(GetCurrentDirectory(), "Offline");
+        }
+
+        /// <summary>
         /// Deletes application's Data folder.
         /// </summary>
         public static void DeleteDataDirectory()

--- a/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
@@ -207,35 +207,37 @@ namespace SolidCP.Installer.Controls
 			{
 				Log.WriteStart("Updating component");
 
-				ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
-				string componentId = element.ID;
-				string componentName = element.GetStringSetting("ComponentName");
-				string componentCode = element.GetStringSetting("ComponentCode");
+                ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
+                string componentId = element.ID;
+                string componentName = element.GetStringSetting("ComponentName");
+                string componentCode = element.GetStringSetting("ComponentCode");
 
-				try
+                try
 				{
-					Log.WriteInfo(string.Format("Updating {0}", componentName));
+                    Log.WriteInfo(string.Format("Updating {0}", componentName));
 
-					string offlineFolder = FileUtils.GetOfflineDataDirectory();
+                    string offlineFolder = FileUtils.GetOfflineDataDirectory();
                     string versionedOfflineFolderPath = Path.Combine(offlineFolder, version);
                     string localFileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
-					string fullOfflineNamePath = Path.Combine(versionedOfflineFolderPath, localFileName);
+                    string fullOfflineNamePath = Path.Combine(versionedOfflineFolderPath, localFileName);
 
                     DialogResult result = DialogResult.None;
 
-                    if (File.Exists(fullOfflineNamePath)) {
+                    if (File.Exists(fullOfflineNamePath))
+                    {
                         Log.WriteInfo("Use offline installer");
                         Loader form = new Loader(localFileName, componentCode, version, (e) => AppContext.AppForm.ShowError(e), true);
                         result = form.ShowDialog(this);
                     }
-					else {
+                    else
+                    {
                         //download installer
                         Log.WriteInfo("Download installer");
                         Loader form = new Loader(fileName, (e) => AppContext.AppForm.ShowError(e));
                         result = form.ShowDialog(this);
-                    }                    
-					
-					if (result == DialogResult.OK)
+                    }
+
+                    if (result == DialogResult.OK)
 					{
 						//run installer
 						string tmpFolder = FileUtils.GetTempDirectory();

--- a/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
@@ -210,13 +210,31 @@ namespace SolidCP.Installer.Controls
 				ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
 				string componentId = element.ID;
 				string componentName = element.GetStringSetting("ComponentName");
+				string componentCode = element.GetStringSetting("ComponentCode");
 
 				try
 				{
 					Log.WriteInfo(string.Format("Updating {0}", componentName));
-					//download installer
-					Loader form = new Loader(fileName, (e) => AppContext.AppForm.ShowError(e));
-					DialogResult result = form.ShowDialog(this);
+
+					string offlineFolder = FileUtils.GetOfflineDataDirectory();
+                    string versionedOfflineFolderPath = Path.Combine(offlineFolder, version);
+                    string localFileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
+					string fullOfflineNamePath = Path.Combine(versionedOfflineFolderPath, localFileName);
+
+                    DialogResult result = DialogResult.None;
+
+                    if (File.Exists(fullOfflineNamePath)) {
+                        Log.WriteInfo("Use offline installer");
+                        Loader form = new Loader(localFileName, componentCode, version, (e) => AppContext.AppForm.ShowError(e), true);
+                        result = form.ShowDialog(this);
+                    }
+					else {
+                        //download installer
+                        Log.WriteInfo("Download installer");
+                        Loader form = new Loader(fileName, (e) => AppContext.AppForm.ShowError(e));
+                        result = form.ShowDialog(this);
+                    }                    
+					
 					if (result == DialogResult.OK)
 					{
 						//run installer

--- a/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Installer/Controls/ComponentControl.cs
@@ -48,164 +48,164 @@ using SolidCP.Installer.Configuration;
 
 namespace SolidCP.Installer.Controls
 {
-	/// <summary>
-	/// Component control
-	/// </summary>
-	internal partial class ComponentControl : ResultViewControl
-	{
-		delegate void ReloadApplicationCallback();
+    /// <summary>
+    /// Component control
+    /// </summary>
+    internal partial class ComponentControl : ResultViewControl
+    {
+        delegate void ReloadApplicationCallback();
 
-		/// <summary>
-		/// Initializes a new instance of the ComponentControl class.
-		/// </summary>
-		public ComponentControl()
-		{
-			InitializeComponent();
-		}
+        /// <summary>
+        /// Initializes a new instance of the ComponentControl class.
+        /// </summary>
+        public ComponentControl()
+        {
+            InitializeComponent();
+        }
 
-		/// <summary>
-		/// Shows control
-		/// </summary>
-		/// <param name="context"></param>
-		public override void ShowControl(SCPAppContext context)
-		{
-			base.ShowControl(context);
-			if (!IsInitialized)
-			{
-				ComponentConfigElement element = context.ScopeNode.Tag as ComponentConfigElement;
-				if (element != null)
-				{
-					txtApplication.Text = element.GetStringSetting("ApplicationName");
-					txtComponent.Text = element.GetStringSetting("ComponentName");
-					txtVersion.Text = element.GetStringSetting("Release");
-					lblDescription.Text = element.GetStringSetting("ComponentDescription");
+        /// <summary>
+        /// Shows control
+        /// </summary>
+        /// <param name="context"></param>
+        public override void ShowControl(SCPAppContext context)
+        {
+            base.ShowControl(context);
+            if (!IsInitialized)
+            {
+                ComponentConfigElement element = context.ScopeNode.Tag as ComponentConfigElement;
+                if (element != null)
+                {
+                    txtApplication.Text = element.GetStringSetting("ApplicationName");
+                    txtComponent.Text = element.GetStringSetting("ComponentName");
+                    txtVersion.Text = element.GetStringSetting("Release");
+                    lblDescription.Text = element.GetStringSetting("ComponentDescription");
 
-					string installer = element.GetStringSetting("Installer");
-					string path = element.GetStringSetting("InstallerPath");
-					string type = element.GetStringSetting("InstallerType");
-					if ( string.IsNullOrEmpty(installer) ||
-						string.IsNullOrEmpty(path) || 
-						string.IsNullOrEmpty(type))
-					{
-						btnRemove.Enabled = false;
-						btnSettings.Enabled = false;
-					}
-				}
-				IsInitialized = true;
-			}
-		}
+                    string installer = element.GetStringSetting("Installer");
+                    string path = element.GetStringSetting("InstallerPath");
+                    string type = element.GetStringSetting("InstallerType");
+                    if (string.IsNullOrEmpty(installer) ||
+                        string.IsNullOrEmpty(path) ||
+                        string.IsNullOrEmpty(type))
+                    {
+                        btnRemove.Enabled = false;
+                        btnSettings.Enabled = false;
+                    }
+                }
+                IsInitialized = true;
+            }
+        }
 
-		/// <summary>
-		/// Action on Remove button click
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void OnRemoveClick(object sender, EventArgs e)
-		{
-			UninstallComponent();
-		}
+        /// <summary>
+        /// Action on Remove button click
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnRemoveClick(object sender, EventArgs e)
+        {
+            UninstallComponent();
+        }
 
-		/// <summary>
-		/// Action on Settings button click
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void OnSettingsClick(object sender, EventArgs e)
-		{
-			SetupComponent();
-		}
+        /// <summary>
+        /// Action on Settings button click
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnSettingsClick(object sender, EventArgs e)
+        {
+            SetupComponent();
+        }
 
-		/// <summary>
-		/// Action on Check For Update button click
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void OnCheckUpdateClick(object sender, EventArgs e)
-		{
-			//start check in the separate thread
-			AppContext.AppForm.StartAsyncProgress("Connecting...", true);
-			ThreadStart threadDelegate = new ThreadStart(CheckForUpdate);
-			Thread newThread = new Thread(threadDelegate);
-			newThread.Start();
-		}
+        /// <summary>
+        /// Action on Check For Update button click
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnCheckUpdateClick(object sender, EventArgs e)
+        {
+            //start check in the separate thread
+            AppContext.AppForm.StartAsyncProgress("Connecting...", true);
+            ThreadStart threadDelegate = new ThreadStart(CheckForUpdate);
+            Thread newThread = new Thread(threadDelegate);
+            newThread.Start();
+        }
 
-		/// <summary>
-		/// Checks for component update
-		/// </summary>
-		private void CheckForUpdate()
-		{
-			Log.WriteStart("Checking for component update");
-			ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
+        /// <summary>
+        /// Checks for component update
+        /// </summary>
+        private void CheckForUpdate()
+        {
+            Log.WriteStart("Checking for component update");
+            ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
 
-			string componentName = element.GetStringSetting("ComponentName");
-			string componentCode = element.GetStringSetting("ComponentCode");
-			string release = element.GetStringSetting("Release");		
-	
-			// call web service
-			DataSet ds;
-			try
-			{
-				Log.WriteInfo(string.Format("Checking {0} {1}", componentName, release));
-				//
-				var webService = ServiceProviderProxy.GetInstallerWebService();
-				ds = webService.GetComponentUpdate(componentCode, release);
-				//
-				Log.WriteEnd("Component update checked");
-				AppContext.AppForm.FinishProgress();
-			}
-			catch (Exception ex)
-			{
-				Log.WriteError("Service error", ex);
-				AppContext.AppForm.FinishProgress();
-				AppContext.AppForm.ShowServerError();
-				return;
-			}
+            string componentName = element.GetStringSetting("ComponentName");
+            string componentCode = element.GetStringSetting("ComponentCode");
+            string release = element.GetStringSetting("Release");
 
-			string appName = AppContext.AppForm.Text;
-			if (ds != null && ds.Tables.Count > 0 && ds.Tables[0].Rows.Count > 0)
-			{
-				DataRow row = ds.Tables[0].Rows[0];
-				string newVersion = row["Version"].ToString();
-				Log.WriteInfo(string.Format("Version {0} is available for download", newVersion)); 
+            // call web service
+            DataSet ds;
+            try
+            {
+                Log.WriteInfo(string.Format("Checking {0} {1}", componentName, release));
+                //
+                var webService = ServiceProviderProxy.GetInstallerWebService();
+                ds = webService.GetComponentUpdate(componentCode, release);
+                //
+                Log.WriteEnd("Component update checked");
+                AppContext.AppForm.FinishProgress();
+            }
+            catch (Exception ex)
+            {
+                Log.WriteError("Service error", ex);
+                AppContext.AppForm.FinishProgress();
+                AppContext.AppForm.ShowServerError();
+                return;
+            }
 
-				string message = string.Format("{0} {1} is available now.\nWould you like to install new version?", componentName, newVersion);
-				if (MessageBox.Show(AppContext.AppForm, message, appName, MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
-				{
-					string fileToDownload = row["UpgradeFilePath"].ToString();
-					string installerPath = row["InstallerPath"].ToString();
-					string installerType = row["InstallerType"].ToString();
-					UpdateComponent(fileToDownload, installerPath, installerType, newVersion);
-				}
-			}
-			else
-			{
-				string message = string.Format("Current version of {0} is up to date.", componentName);
-				Log.WriteInfo(message);
-				AppContext.AppForm.ShowInfo(message);
-			}
-		}
+            string appName = AppContext.AppForm.Text;
+            if (ds != null && ds.Tables.Count > 0 && ds.Tables[0].Rows.Count > 0)
+            {
+                DataRow row = ds.Tables[0].Rows[0];
+                string newVersion = row["Version"].ToString();
+                Log.WriteInfo(string.Format("Version {0} is available for download", newVersion));
 
-		delegate void UpdateComponentCallback(string fileName, string path, string type, string version);
+                string message = string.Format("{0} {1} is available now.\nWould you like to install new version?", componentName, newVersion);
+                if (MessageBox.Show(AppContext.AppForm, message, appName, MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
+                {
+                    string fileToDownload = row["UpgradeFilePath"].ToString();
+                    string installerPath = row["InstallerPath"].ToString();
+                    string installerType = row["InstallerType"].ToString();
+                    UpdateComponent(fileToDownload, installerPath, installerType, newVersion);
+                }
+            }
+            else
+            {
+                string message = string.Format("Current version of {0} is up to date.", componentName);
+                Log.WriteInfo(message);
+                AppContext.AppForm.ShowInfo(message);
+            }
+        }
 
-		/// <summary>
-		/// Runs component update
-		/// </summary>
-		/// <param name="fileName"></param>
-		/// <param name="path"></param>
-		/// <param name="type"></param>
-		private void UpdateComponent(string fileName, string path, string type, string version)
-		{
-			// InvokeRequired required compares the thread ID of the
-			// calling thread to the thread ID of the creating thread.
-			// If these threads are different, it returns true.
-			if (this.InvokeRequired)
-			{
-				UpdateComponentCallback callBack = new UpdateComponentCallback(UpdateComponent);
-				Invoke(callBack, new object[] { fileName, path, type, version });
-			}
-			else
-			{
-				Log.WriteStart("Updating component");
+        delegate void UpdateComponentCallback(string fileName, string path, string type, string version);
+
+        /// <summary>
+        /// Runs component update
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="path"></param>
+        /// <param name="type"></param>
+        private void UpdateComponent(string fileName, string path, string type, string version)
+        {
+            // InvokeRequired required compares the thread ID of the
+            // calling thread to the thread ID of the creating thread.
+            // If these threads are different, it returns true.
+            if (this.InvokeRequired)
+            {
+                UpdateComponentCallback callBack = new UpdateComponentCallback(UpdateComponent);
+                Invoke(callBack, new object[] { fileName, path, type, version });
+            }
+            else
+            {
+                Log.WriteStart("Updating component");
 
                 ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
                 string componentId = element.ID;
@@ -213,7 +213,7 @@ namespace SolidCP.Installer.Controls
                 string componentCode = element.GetStringSetting("ComponentCode");
 
                 try
-				{
+                {
                     Log.WriteInfo(string.Format("Updating {0}", componentName));
 
                     string offlineFolder = FileUtils.GetOfflineDataDirectory();
@@ -238,180 +238,180 @@ namespace SolidCP.Installer.Controls
                     }
 
                     if (result == DialogResult.OK)
-					{
-						//run installer
-						string tmpFolder = FileUtils.GetTempDirectory();
-						string installerPath = Path.Combine(tmpFolder, path);
-						Update();
-						string method = "Update";
-						Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
-						Hashtable args = new Hashtable();
-						args["ComponentId"] = componentId;
-						args["ShellVersion"] = AppContext.AppForm.Version;
-						args["BaseDirectory"] = FileUtils.GetCurrentDirectory();
-						args["UpdateVersion"] = version;
-						args["Installer"] = Path.GetFileName(fileName);
-						args["InstallerType"] = type;
-						args["InstallerPath"] = path;
-						args["InstallerFolder"] = tmpFolder;
-						args["IISVersion"] = Global.IISVersion;
-						args["ParentForm"] = FindForm();
+                    {
+                        //run installer
+                        string tmpFolder = FileUtils.GetTempDirectory();
+                        string installerPath = Path.Combine(tmpFolder, path);
+                        Update();
+                        string method = "Update";
+                        Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
+                        Hashtable args = new Hashtable();
+                        args["ComponentId"] = componentId;
+                        args["ShellVersion"] = AppContext.AppForm.Version;
+                        args["BaseDirectory"] = FileUtils.GetCurrentDirectory();
+                        args["UpdateVersion"] = version;
+                        args["Installer"] = Path.GetFileName(fileName);
+                        args["InstallerType"] = type;
+                        args["InstallerPath"] = path;
+                        args["InstallerFolder"] = tmpFolder;
+                        args["IISVersion"] = Global.IISVersion;
+                        args["ParentForm"] = FindForm();
 
-						result = (DialogResult)AssemblyLoader.Execute(installerPath, type, method, new object[] { args });
-						Log.WriteInfo(string.Format("Installer returned {0}", result));
-						Log.WriteEnd("Installer finished");
-						Update();
-						if (result == DialogResult.OK)
-						{
-							ReloadApplication();
-						}
-						FileUtils.DeleteTempDirectory();
-					}
-					Log.WriteEnd("Update completed");
-				}
-				catch (Exception ex)
-				{
-					Log.WriteError("Installer error", ex);
-					AppContext.AppForm.ShowError(ex);
-				}
-			}
-		}
+                        result = (DialogResult)AssemblyLoader.Execute(installerPath, type, method, new object[] { args });
+                        Log.WriteInfo(string.Format("Installer returned {0}", result));
+                        Log.WriteEnd("Installer finished");
+                        Update();
+                        if (result == DialogResult.OK)
+                        {
+                            ReloadApplication();
+                        }
+                        FileUtils.DeleteTempDirectory();
+                    }
+                    Log.WriteEnd("Update completed");
+                }
+                catch (Exception ex)
+                {
+                    Log.WriteError("Installer error", ex);
+                    AppContext.AppForm.ShowError(ex);
+                }
+            }
+        }
 
-		/// <summary>
-		/// Uninstalls component
-		/// </summary>
-		private void UninstallComponent()
-		{
-			Log.WriteStart("Uninstalling component");
-			
-			ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
-			string installer = element.GetStringSetting(Global.Parameters.Installer);
-			string path = element.GetStringSetting(Global.Parameters.InstallerPath);
-			string type = element.GetStringSetting(Global.Parameters.InstallerType);
-			string componentId = element.ID;
-			string componentCode = element.GetStringSetting(Global.Parameters.ComponentCode);
-			string componentName = element.GetStringSetting(Global.Parameters.ComponentName);
-			string release = element.GetStringSetting(Global.Parameters.Release);
+        /// <summary>
+        /// Uninstalls component
+        /// </summary>
+        private void UninstallComponent()
+        {
+            Log.WriteStart("Uninstalling component");
 
-			try
-			{
-				Log.WriteInfo(string.Format("Uninstalling {0}", componentName));
-				//download installer
-				Loader form = new Loader(installer, componentCode, release, (e) => AppContext.AppForm.ShowError(e));
-				DialogResult result = form.ShowDialog(this);
-				if (result == DialogResult.OK)
-				{
-					//run installer
-					string tmpFolder = FileUtils.GetTempDirectory();
-					path = Path.Combine(tmpFolder, path);
-					Update();
-					string method = "Uninstall";
-					//
-					Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
-					//
-					var args = new Hashtable
-					{
-						{ Global.Parameters.ComponentId, componentId },
-						{ Global.Parameters.ComponentCode, componentCode },
-						{ Global.Parameters.ShellVersion, AppContext.AppForm.Version },
-						{ Global.Parameters.BaseDirectory, FileUtils.GetCurrentDirectory() },
-						{ Global.Parameters.IISVersion, Global.IISVersion },
-						{ Global.Parameters.ParentForm,  FindForm() },
-					};
-					//
-					result = (DialogResult)AssemblyLoader.Execute(path, type, method, new object[] { args });
-					//
-					Log.WriteInfo(string.Format("Installer returned {0}", result));
-					Log.WriteEnd("Installer finished");
-					Update();
-					ReloadApplication();
-					FileUtils.DeleteTempDirectory();
-					
-				}
-				Log.WriteEnd("Uninstall completed");
-			}
-			catch (Exception ex)
-			{
-				Log.WriteError("Installer error", ex);
-				AppContext.AppForm.ShowError(ex);
-			}
-		}
+            ComponentConfigElement element = AppContext.ScopeNode.Tag as ComponentConfigElement;
+            string installer = element.GetStringSetting(Global.Parameters.Installer);
+            string path = element.GetStringSetting(Global.Parameters.InstallerPath);
+            string type = element.GetStringSetting(Global.Parameters.InstallerType);
+            string componentId = element.ID;
+            string componentCode = element.GetStringSetting(Global.Parameters.ComponentCode);
+            string componentName = element.GetStringSetting(Global.Parameters.ComponentName);
+            string release = element.GetStringSetting(Global.Parameters.Release);
 
-		/// <summary>
-		/// Setup component
-		/// </summary>
-		private void SetupComponent()
-		{
-			Log.WriteStart("Starting component setup");
-
-			var element = AppContext.ScopeNode.Tag as ComponentConfigElement;
-
-			string installer = element.GetStringSetting("Installer");
-			string path = element.GetStringSetting("InstallerPath");
-			string type = element.GetStringSetting("InstallerType");
-			string componentId = element.ID;
-			string ccode = element.GetStringSetting("ComponentCode");
-			string componentName = element.GetStringSetting("ComponentName");
-			string cversion = element.GetStringSetting("Release");
-
-			try
-			{
-				Log.WriteInfo(string.Format("Setup {0} {1}", componentName, cversion));
+            try
+            {
+                Log.WriteInfo(string.Format("Uninstalling {0}", componentName));
                 //download installer
-				Loader form = new Loader(installer, ccode, cversion, (e) => AppContext.AppForm.ShowError(e));
-				DialogResult result = form.ShowDialog(this);
-				if (result == DialogResult.OK)
-				{
-					string tmpFolder = Path.Combine(AppContext.CurrentPath, "Tmp");
-					path = Path.Combine(tmpFolder, path);
-					Update();
-					string method = "Setup";
-					Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
-					Hashtable args = new Hashtable();
-					args["ComponentId"] = componentId;
-					args["ShellVersion"] = AppContext.AppForm.Version;
-					args["BaseDirectory"] = FileUtils.GetCurrentDirectory();
+                Loader form = new Loader(installer, componentCode, release, (e) => AppContext.AppForm.ShowError(e));
+                DialogResult result = form.ShowDialog(this);
+                if (result == DialogResult.OK)
+                {
+                    //run installer
+                    string tmpFolder = FileUtils.GetTempDirectory();
+                    path = Path.Combine(tmpFolder, path);
+                    Update();
+                    string method = "Uninstall";
+                    //
+                    Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
+                    //
+                    var args = new Hashtable
+                    {
+                        { Global.Parameters.ComponentId, componentId },
+                        { Global.Parameters.ComponentCode, componentCode },
+                        { Global.Parameters.ShellVersion, AppContext.AppForm.Version },
+                        { Global.Parameters.BaseDirectory, FileUtils.GetCurrentDirectory() },
+                        { Global.Parameters.IISVersion, Global.IISVersion },
+                        { Global.Parameters.ParentForm,  FindForm() },
+                    };
+                    //
+                    result = (DialogResult)AssemblyLoader.Execute(path, type, method, new object[] { args });
+                    //
+                    Log.WriteInfo(string.Format("Installer returned {0}", result));
+                    Log.WriteEnd("Installer finished");
+                    Update();
+                    ReloadApplication();
+                    FileUtils.DeleteTempDirectory();
+
+                }
+                Log.WriteEnd("Uninstall completed");
+            }
+            catch (Exception ex)
+            {
+                Log.WriteError("Installer error", ex);
+                AppContext.AppForm.ShowError(ex);
+            }
+        }
+
+        /// <summary>
+        /// Setup component
+        /// </summary>
+        private void SetupComponent()
+        {
+            Log.WriteStart("Starting component setup");
+
+            var element = AppContext.ScopeNode.Tag as ComponentConfigElement;
+
+            string installer = element.GetStringSetting("Installer");
+            string path = element.GetStringSetting("InstallerPath");
+            string type = element.GetStringSetting("InstallerType");
+            string componentId = element.ID;
+            string ccode = element.GetStringSetting("ComponentCode");
+            string componentName = element.GetStringSetting("ComponentName");
+            string cversion = element.GetStringSetting("Release");
+
+            try
+            {
+                Log.WriteInfo(string.Format("Setup {0} {1}", componentName, cversion));
+                //download installer
+                Loader form = new Loader(installer, ccode, cversion, (e) => AppContext.AppForm.ShowError(e));
+                DialogResult result = form.ShowDialog(this);
+                if (result == DialogResult.OK)
+                {
+                    string tmpFolder = Path.Combine(AppContext.CurrentPath, "Tmp");
+                    path = Path.Combine(tmpFolder, path);
+                    Update();
+                    string method = "Setup";
+                    Log.WriteStart(string.Format("Running installer {0}.{1} from {2}", type, method, path));
+                    Hashtable args = new Hashtable();
+                    args["ComponentId"] = componentId;
+                    args["ShellVersion"] = AppContext.AppForm.Version;
+                    args["BaseDirectory"] = FileUtils.GetCurrentDirectory();
                     args["IISVersion"] = Global.IISVersion;
-					args["ParentForm"] = FindForm();
-					args[Global.Parameters.ShellMode] = Global.VisualInstallerShell;
-					//
-					result = (DialogResult)AssemblyLoader.Execute(path, type, method, new object[] { args });
-					//
-					Log.WriteInfo(string.Format("Installer returned {0}", result));
-					Log.WriteEnd("Installer finished");
+                    args["ParentForm"] = FindForm();
+                    args[Global.Parameters.ShellMode] = Global.VisualInstallerShell;
+                    //
+                    result = (DialogResult)AssemblyLoader.Execute(path, type, method, new object[] { args });
+                    //
+                    Log.WriteInfo(string.Format("Installer returned {0}", result));
+                    Log.WriteEnd("Installer finished");
 
-					if (result == DialogResult.OK)
-					{
-						ReloadApplication();
-					}
-					FileUtils.DeleteTempDirectory();
-				}
-				Log.WriteEnd("Component setup completed");
-			}
-			catch (Exception ex)
-			{
-				Log.WriteError("Installer error", ex);
-				this.AppContext.AppForm.ShowError(ex);
-			}
-		}
+                    if (result == DialogResult.OK)
+                    {
+                        ReloadApplication();
+                    }
+                    FileUtils.DeleteTempDirectory();
+                }
+                Log.WriteEnd("Component setup completed");
+            }
+            catch (Exception ex)
+            {
+                Log.WriteError("Installer error", ex);
+                this.AppContext.AppForm.ShowError(ex);
+            }
+        }
 
-		/// <summary>
-		/// Thread safe application reload
-		/// </summary>
-		private void ReloadApplication()
-		{
-			// InvokeRequired required compares the thread ID of the
-			// calling thread to the thread ID of the creating thread.
-			// If these threads are different, it returns true.
-			if (this.InvokeRequired)
-			{
-				ReloadApplicationCallback callback = new ReloadApplicationCallback(ReloadApplication);
-				Invoke(callback, null);
-			}
-			else
-			{
-				AppContext.AppForm.ReloadApplication();
-			}
-		}
-	}
+        /// <summary>
+        /// Thread safe application reload
+        /// </summary>
+        private void ReloadApplication()
+        {
+            // InvokeRequired required compares the thread ID of the
+            // calling thread to the thread ID of the creating thread.
+            // If these threads are different, it returns true.
+            if (this.InvokeRequired)
+            {
+                ReloadApplicationCallback callback = new ReloadApplicationCallback(ReloadApplication);
+                Invoke(callback, null);
+            }
+            else
+            {
+                AppContext.AppForm.ReloadApplication();
+            }
+        }
+    }
 }

--- a/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
@@ -39,81 +39,81 @@ using SolidCP.Setup.Actions;
 
 namespace SolidCP.Setup
 {
-	/// <summary>
-	/// Shows sql script process.
-	/// </summary>
-	public sealed class SqlProcess
-	{
-		private string scriptFile; 
-		private string connectionString;
-		private string database;
+    /// <summary>
+    /// Shows sql script process.
+    /// </summary>
+    public sealed class SqlProcess
+    {
+        private string scriptFile;
+        private string connectionString;
+        private string database;
 
-		public event EventHandler<ActionProgressEventArgs<int>> ProgressChange;
-		
-		/// <summary>
-		/// Initializes a new instance of the class.
-		/// </summary>
-		/// <param name="file">Sql script file</param>
-		/// <param name="connection">Sql connection string</param>
-		/// <param name="db">Sql server database name</param>
-		public SqlProcess(string file, string connection, string db)
-		{
-			this.scriptFile = file;
-			this.connectionString = connection;
-			this.database = db;
-		}
+        public event EventHandler<ActionProgressEventArgs<int>> ProgressChange;
 
-		private void OnProgressChange(int percentage)
-		{
-			if (ProgressChange == null)
-				return;
-			//
-			ProgressChange(this, new ActionProgressEventArgs<int>
-			{
-				EventData = percentage
-			});
-		}
+        /// <summary>
+        /// Initializes a new instance of the class.
+        /// </summary>
+        /// <param name="file">Sql script file</param>
+        /// <param name="connection">Sql connection string</param>
+        /// <param name="db">Sql server database name</param>
+        public SqlProcess(string file, string connection, string db)
+        {
+            this.scriptFile = file;
+            this.connectionString = connection;
+            this.database = db;
+        }
 
-		/// <summary>
-		/// Executes sql script file.
-		/// </summary>
-		internal void Run()
-		{
-			int commandCount = 0;
-			int i = 0;
-			string sql = string.Empty;
+        private void OnProgressChange(int percentage)
+        {
+            if (ProgressChange == null)
+                return;
+            //
+            ProgressChange(this, new ActionProgressEventArgs<int>
+            {
+                EventData = percentage
+            });
+        }
 
-			try
-			{
-				using (StreamReader sr = new StreamReader(scriptFile))
-				{
-					while( null != (sql = ReadNextStatementFromStream(sr))) 
-					{
-						commandCount++;
-					}					
-				}
-			}
-			catch(Exception ex)
-			{
-				throw new Exception("Can't read SQL script " + scriptFile, ex);
-			}
+        /// <summary>
+        /// Executes sql script file.
+        /// </summary>
+        internal void Run()
+        {
+            int commandCount = 0;
+            int i = 0;
+            string sql = string.Empty;
 
-			Log.WriteInfo(string.Format("Executing {0} database commands", commandCount));
-			//
-			OnProgressChange(0);
-			//
-			SqlConnection connection = new SqlConnection(connectionString);
+            try
+            {
+                using (StreamReader sr = new StreamReader(scriptFile))
+                {
+                    while (null != (sql = ReadNextStatementFromStream(sr)))
+                    {
+                        commandCount++;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Can't read SQL script " + scriptFile, ex);
+            }
 
-			try
-			{
-				// iterate through "GO" delimited command text
-				using (StreamReader reader = new StreamReader(scriptFile))
-				{
-					SqlCommand command = new SqlCommand();
-					connection.Open();
-					command.Connection = connection;
-					command.CommandType = System.Data.CommandType.Text;
-					command.CommandTimeout = 600;
+            Log.WriteInfo(string.Format("Executing {0} database commands", commandCount));
+            //
+            OnProgressChange(0);
+            //
+            SqlConnection connection = new SqlConnection(connectionString);
+
+            try
+            {
+                // iterate through "GO" delimited command text
+                using (StreamReader reader = new StreamReader(scriptFile))
+                {
+                    SqlCommand command = new SqlCommand();
+                    connection.Open();
+                    command.Connection = connection;
+                    command.CommandType = System.Data.CommandType.Text;
+                    command.CommandTimeout = 600;
 
                     while (null != (sql = ReadNextStatementFromStream(reader)))
                     {
@@ -139,54 +139,54 @@ namespace SolidCP.Setup
                         }
                     }
                 }
-			}
-			catch (Exception ex)
-			{
-				throw new Exception("Can't run SQL script " + scriptFile, ex);
-			}
-			finally
-			{
-				connection.Close();
-			}
-		}
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Can't run SQL script " + scriptFile, ex);
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
 
-		private string ReadNextStatementFromStream(StreamReader reader)
-		{
-			StringBuilder sb = new StringBuilder();
-			string lineOfText;
-	
-			while(true) 
-			{
-				lineOfText = reader.ReadLine();
-				if( lineOfText == null ) 
-				{
-					if( sb.Length > 0 ) 
-					{
-						return sb.ToString();
-					}
-					else 
-					{
-						return null;
-					}
-				}
+        private string ReadNextStatementFromStream(StreamReader reader)
+        {
+            StringBuilder sb = new StringBuilder();
+            string lineOfText;
 
-				if(lineOfText.TrimEnd().ToUpper() == "GO") 
-				{
-					break;
-				}
-				
-				sb.Append(lineOfText + Environment.NewLine);
-			}
+            while (true)
+            {
+                lineOfText = reader.ReadLine();
+                if (lineOfText == null)
+                {
+                    if (sb.Length > 0)
+                    {
+                        return sb.ToString();
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
 
-			return sb.ToString();
-		}
+                if (lineOfText.TrimEnd().ToUpper() == "GO")
+                {
+                    break;
+                }
 
-		private string ProcessInstallVariables(string input)
-		{
-			//replace install variables
-			string output = input;
-			output = output.Replace("${install.database}", database);
-			return output;
-		}
-	}
+                sb.Append(lineOfText + Environment.NewLine);
+            }
+
+            return sb.ToString();
+        }
+
+        private string ProcessInstallVariables(string input)
+        {
+            //replace install variables
+            string output = input;
+            output = output.Replace("${install.database}", database);
+            return output;
+        }
+    }
 }

--- a/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
@@ -118,7 +118,11 @@ namespace SolidCP.Setup
 					while (null != (sql = ReadNextStatementFromStream(reader)))
 					{
 						sql = ProcessInstallVariables(sql);
-						command.CommandText = sql;
+                        if (string.IsNullOrEmpty(sql)) // 
+                        {
+                            continue; // skip an empty line in update_db.sql 
+                        }
+                        command.CommandText = sql;
 						try
 						{
 							command.ExecuteNonQuery();

--- a/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
+++ b/SolidCP.Installer/Sources/SolidCP.Setup/Common/SqlProcess.cs
@@ -115,30 +115,30 @@ namespace SolidCP.Setup
 					command.CommandType = System.Data.CommandType.Text;
 					command.CommandTimeout = 600;
 
-					while (null != (sql = ReadNextStatementFromStream(reader)))
-					{
-						sql = ProcessInstallVariables(sql);
+                    while (null != (sql = ReadNextStatementFromStream(reader)))
+                    {
+                        sql = ProcessInstallVariables(sql);
                         if (string.IsNullOrEmpty(sql)) // 
                         {
                             continue; // skip an empty line in update_db.sql 
                         }
                         command.CommandText = sql;
-						try
-						{
-							command.ExecuteNonQuery();
-						}
-						catch (Exception ex)
-						{
-							throw new Exception("Error executing SQL command: " + sql, ex);
-						}
+                        try
+                        {
+                            command.ExecuteNonQuery();
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new Exception("Error executing SQL command: " + sql, ex);
+                        }
 
-						i++;
-						if (commandCount != 0)
-						{
-							OnProgressChange(Convert.ToInt32(i * 100 / commandCount));
-						}
-					}
-				}
+                        i++;
+                        if (commandCount != 0)
+                        {
+                            OnProgressChange(Convert.ToInt32(i * 100 / commandCount));
+                        }
+                    }
+                }
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
# Description

Starting from SolidCP version 1.4.8, the updater was broken, especially for Enterprise Server. This caused incomplete database updates and broke the IIS pool, leading to an unexplained 503 error. The issue could be fixed by restarting the server and manually running the **update_db.sql**.

The problem was likely caused by an empty character being accidentally added to the **update_db.sql** file in version 1.4.9, which broke the update process.
Fixed this issue:
```
System.Exception: Can't run SQL script C:\Program Files (x86)\SolidCP Installer\Tmp\setup\update_db.sql ---> System.Exception: Error executing SQL command:  ---> System.InvalidOperationException: ExecuteNonQuery: CommandText property has not been initialized
   at System.Data.SqlClient.SqlCommand.ValidateCommand(String method, Boolean async)
   at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, String methodName, Boolean sendToPipe, Int32 timeout, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry)
   at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
   at SolidCP.Setup.SqlProcess.Run()
   --- End of inner exception stack trace ---
   at SolidCP.Setup.SqlProcess.Run()
   --- End of inner exception stack trace ---
   at SolidCP.Setup.SqlProcess.Run()
   at SolidCP.Setup.ExpressInstallPage.RunSqlScript(String connectionString, String database, String fileName)
   at SolidCP.Setup.ExpressInstallPage.ExecuteSqlScript(String file)

```


Additionally, the option to use a partial offline mode was added. This is useful when there are corrupted files in the network (like in the case with SolidCP-EnterpriseServer-Update.zip), which prevent components from being updated over the network. The new feature allows you to add the fixed setup.dll to the *-update.zip to update without issues.

To use offline mode, you need to create an "Offline" folder in the SolidCP Installer directory, then create a folder with the version number (e.g., 1.5.1), and place the *-Update.zip files in that folder. A network connection is still required to get the version number for the update.

