### PR TITLE
Create mailbox - user selector - use only AccountId argument

### DIFF
--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/UserSelector.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/UserSelector.ascx
@@ -61,7 +61,7 @@
 						                    <ItemStyle Width="50%"></ItemStyle>
 						                    <ItemTemplate>
 							                    <asp:Image ID="img1" runat="server" ImageUrl='<%# GetAccountImage() %>' ImageAlign="AbsMiddle" />
-							                    <asp:LinkButton ID="cmdSelectAccount" CommandName="SelectAccount" CommandArgument='<%# Eval("AccountName").ToString() + "|" + Eval("DisplayName").ToString() + "|" + Eval("PrimaryEmailAddress")+ "|" + Eval("AccountId")+ "|" + Eval("SamAccountName")+ "|" + Eval("SubscriberNumber")%>' runat="server" Text='<%# Eval("DisplayName") %>'></asp:LinkButton>
+							                    <asp:LinkButton ID="cmdSelectAccount" CommandName="SelectAccount" CommandArgument='<%# Eval("AccountId")%>' runat="server" Text='<%# Eval("DisplayName") %>'></asp:LinkButton>
 						                    </ItemTemplate>
 					                    </asp:TemplateField>
 					                    <asp:TemplateField meta:resourcekey="gvAccountsEmail" >

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/UserSelector.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ExchangeServer/UserControls/UserSelector.ascx.cs
@@ -308,19 +308,7 @@ namespace SolidCP.Portal.ExchangeServer.UserControls
         {
             if (e.CommandName == "SelectAccount")
             {
-                string[] parts = e.CommandArgument.ToString().Split('|');
-
-                /*
-                OrganizationUser account = new OrganizationUser();
-                account.AccountName = parts[0];
-                account.DisplayName = parts[1];
-                account.PrimaryEmailAddress = parts[2];
-                account.AccountId = Utils.ParseInt(parts[3]);
-                account.SamAccountName = parts[4];
-                account.SubscriberNumber = parts[5];
-                 */
-
-                int AccountId = Utils.ParseInt(parts[3]);
+                int AccountId = Utils.ParseInt(e.CommandArgument.ToString());
 
                 OrganizationUser account = ES.Services.Organizations.GetUserGeneralSettings(PanelRequest.ItemID, AccountId);
 


### PR DESCRIPTION
# Description

- Create mailbox - user selector - use only AccountId argument

Fixes # (issue)

You cannot select an existing user if the display name contains "|". There is no need to split the arguments here as only AccountId is used.