### PR TITLE
[HyperV2012R2+] Refactor for performance

### DIFF
--- a/SolidCP/Sources/SolidCP.Providers.Base/SolidCP.Providers.Base.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Base/SolidCP.Providers.Base.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Virtualization\Config\LibraryItem.cs" />
     <Compile Include="Virtualization\LogicalDisk.cs" />
     <Compile Include="Virtualization\DvdDriveInfo.cs" />
+    <Compile Include="Virtualization\CimSessionMode.cs" />
     <Compile Include="Virtualization\MonitoredObjectAlert.cs" />
     <Compile Include="Virtualization\MonitoredObjectEvent.cs" />
     <Compile Include="Virtualization\MountedDiskInfo.cs" />

--- a/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/CimSessionMode.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/CimSessionMode.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SolidCP.Providers.Virtualization
+{
+    public enum CimSessionMode
+    {
+        DCom = 0,
+        WSMan = 1
+    }
+}

--- a/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/SummaryInformationRequest.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Base/Virtualization/SummaryInformationRequest.cs
@@ -55,6 +55,7 @@ namespace SolidCP.Providers.Virtualization
         GuestOperatingSystem = 106,
         Snapshots = 107,
         AsynchronousTasks = 108,
-        HealthState  = 109
+        HealthState  = 109,
+        VirtualSystemSubType = 135 //VM Generation
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Data/VirtualMachineData.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Data/VirtualMachineData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolidCP.Providers.Virtualization
+{
+    public class VirtualMachineData
+    {
+        public VirtualMachine VM { get; set; }
+        public PSObject RawObject { get; set; }
+    }
+}

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Extensions/PSObjectExtension.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Extensions/PSObjectExtension.cs
@@ -12,15 +12,18 @@ namespace SolidCP.Providers.Virtualization
     {
         #region Properties
 
-        public static object GetProperty(this PSObject obj, string name)
+        public static object GetProperty(this PSObject obj, string name, bool suppressErrors = false)
         {
+            if (suppressErrors)
+                return obj?.Members[name]?.Value;
+
             return obj.Members[name].Value;
         }
         public static T GetProperty<T>(this PSObject obj, string name)
         {
             return (T)obj.Members[name].Value;
         }
-        public static T GetEnum<T>(this PSObject obj, string name, T? defaultValue = null) where T : struct
+        public static T GetEnum<T>(this PSObject obj, string name, T? defaultValue = null, bool suppressErrors = false) where T : struct
         {
             try
             {
@@ -28,7 +31,7 @@ namespace SolidCP.Providers.Virtualization
             }
             catch
             {
-                if (defaultValue.HasValue) return defaultValue.Value;
+                if (defaultValue.HasValue && suppressErrors) return defaultValue.Value;
                 throw;
             }
         }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
@@ -13,14 +13,12 @@ namespace SolidCP.Providers.Virtualization
     public class BiosHelper
     {
         private PowerShellManager _powerShell;
-        private MiManager _mi;
         private DvdDriveHelper _dvdDriveHelper;
         private HardDriveHelper _hardDriveHelper;
 
-        public BiosHelper(PowerShellManager powerShellManager, MiManager mi, DvdDriveHelper dvdDriveHelper, HardDriveHelper hardDriveHelper)
+        public BiosHelper(PowerShellManager powerShellManager, DvdDriveHelper dvdDriveHelper, HardDriveHelper hardDriveHelper)
         {
             _powerShell = powerShellManager;
-            _mi = mi;
             _dvdDriveHelper = dvdDriveHelper;
             _hardDriveHelper = hardDriveHelper;
         }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
@@ -10,9 +10,22 @@ using System.Threading.Tasks;
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class BiosHelper
+    public class BiosHelper
     {
-        public static BiosInfo Get(PowerShellManager powerShell, string name, int generation)
+        private PowerShellManager _powerShell;
+        private MiManager _mi;
+        private DvdDriveHelper _dvdDriveHelper;
+        private HardDriveHelper _hardDriveHelper;
+
+        public BiosHelper(PowerShellManager powerShellManager, MiManager mi, DvdDriveHelper dvdDriveHelper, HardDriveHelper hardDriveHelper)
+        {
+            _powerShell = powerShellManager;
+            _mi = mi;
+            _dvdDriveHelper = dvdDriveHelper;
+            _hardDriveHelper = hardDriveHelper;
+        }
+
+        public BiosInfo Get(string name, int generation)
         {
             BiosInfo info = new BiosInfo();
 
@@ -23,7 +36,7 @@ namespace SolidCP.Providers.Virtualization
 
                 cmd.Parameters.Add("VMName", name);
 
-                Collection<PSObject> result = powerShell.Execute(cmd, true);
+                Collection<PSObject> result = _powerShell.Execute(cmd, true);
                 if (result != null && result.Count > 0)
                 {
                     info.NumLockEnabled = true;
@@ -65,7 +78,7 @@ namespace SolidCP.Providers.Virtualization
 
                 cmd.Parameters.Add("VMName", name);
 
-                Collection<PSObject> result = powerShell.Execute(cmd, true);
+                Collection<PSObject> result = _powerShell.Execute(cmd, true);
                 if (result != null && result.Count > 0)
                 {
                     info.NumLockEnabled = Convert.ToBoolean(result[0].GetProperty("NumLockEnabled"));
@@ -87,7 +100,7 @@ namespace SolidCP.Providers.Virtualization
             return info;
         }
 
-        public static void Update(PowerShellManager powerShell, VirtualMachine vm, bool bootFromCD, bool numLockEnabled, bool EnableSecureBoot, string secureBootTemplate)
+        public void Update(VirtualMachine vm, bool bootFromCD, bool numLockEnabled, bool EnableSecureBoot, string secureBootTemplate)
         {
             // for Win2012R2+ and Win8.1+
             if (vm.Generation == 2)
@@ -107,11 +120,11 @@ namespace SolidCP.Providers.Virtualization
                 }
 
                 if (bootFromCD)
-                    cmd.Parameters.Add("FirstBootDevice", DvdDriveHelper.GetPS(powerShell, vm.Name));
+                    cmd.Parameters.Add("FirstBootDevice", _dvdDriveHelper.GetPS(vm.Name));
                 else
-                    cmd.Parameters.Add("FirstBootDevice", HardDriveHelper.GetPS(powerShell, vm.Name).FirstOrDefault());
+                    cmd.Parameters.Add("FirstBootDevice", _hardDriveHelper.GetPS(vm.Name).FirstOrDefault());
 
-                powerShell.Execute(cmd, true);
+                _powerShell.Execute(cmd, true);
             }
             // for others win and linux
             else
@@ -124,7 +137,7 @@ namespace SolidCP.Providers.Virtualization
                     : new[] { "IDE", "CD", "LegacyNetworkAdapter", "Floppy" };
                 cmd.Parameters.Add("StartupOrder", bootOrder);
 
-                powerShell.Execute(cmd, true);
+                _powerShell.Execute(cmd, true);
             }
         }
     }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/BiosHelper.cs
@@ -23,7 +23,7 @@ namespace SolidCP.Providers.Virtualization
             _hardDriveHelper = hardDriveHelper;
         }
 
-        public BiosInfo Get(PSObject vmPSObj, int generation)
+        public BiosInfo Get(VirtualMachineData vmData, int generation)
         {
             BiosInfo info = new BiosInfo();
 
@@ -32,9 +32,8 @@ namespace SolidCP.Providers.Virtualization
             {
                 Command cmd = new Command("Get-VMFirmware");
 
-                cmd.Parameters.Add("VM", vmPSObj);
+                Collection<PSObject> result = _powerShell.ExecuteOnVm(cmd, vmData);
 
-                Collection<PSObject> result = _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
                 if (result != null && result.Count > 0)
                 {
                     info.NumLockEnabled = true;
@@ -74,9 +73,8 @@ namespace SolidCP.Providers.Virtualization
             {
                 Command cmd = new Command("Get-VMBios");
 
-                cmd.Parameters.Add("VM", vmPSObj);
+                Collection<PSObject> result = _powerShell.ExecuteOnVm(cmd, vmData);
 
-                Collection<PSObject> result = _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
                 if (result != null && result.Count > 0)
                 {
                     info.NumLockEnabled = Convert.ToBoolean(result[0].GetProperty("NumLockEnabled"));
@@ -98,15 +96,14 @@ namespace SolidCP.Providers.Virtualization
             return info;
         }
 
-        public void Update(VirtualMachine vm, PSObject vmPSObj, bool bootFromCD, bool numLockEnabled, bool EnableSecureBoot, string secureBootTemplate)
+        public void Update(VirtualMachineData vmData, bool bootFromCD, bool numLockEnabled, bool EnableSecureBoot, string secureBootTemplate)
         {
             // for Win2012R2+ and Win8.1+
-            if (vm.Generation == 2)
+            if (vmData.VM.Generation == 2)
             {
                 Command cmd = new Command("Set-VMFirmware");
 
-                cmd.Parameters.Add("VM", vmPSObj);
-                if (vm.State == VirtualMachineState.Off)
+                if (vmData.VM.State == VirtualMachineState.Off)
                 {
                     if (EnableSecureBoot)
                     {
@@ -118,24 +115,23 @@ namespace SolidCP.Providers.Virtualization
                 }
 
                 if (bootFromCD)
-                    cmd.Parameters.Add("FirstBootDevice", _dvdDriveHelper.GetPS(vmPSObj));
+                    cmd.Parameters.Add("FirstBootDevice", _dvdDriveHelper.GetPS(vmData));
                 else
-                    cmd.Parameters.Add("FirstBootDevice", _hardDriveHelper.GetPS(vmPSObj).FirstOrDefault());
+                    cmd.Parameters.Add("FirstBootDevice", _hardDriveHelper.GetPS(vmData).FirstOrDefault());
 
-                _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+                _powerShell.ExecuteOnVm(cmd, vmData);
             }
             // for others win and linux
             else
             {
                 Command cmd = new Command("Set-VMBios");
 
-                cmd.Parameters.Add("VM", vmPSObj);
                 var bootOrder = bootFromCD
                     ? new[] { "CD", "IDE", "LegacyNetworkAdapter", "Floppy" }
                     : new[] { "IDE", "CD", "LegacyNetworkAdapter", "Floppy" };
                 cmd.Parameters.Add("StartupOrder", bootOrder);
 
-                _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+                _powerShell.ExecuteOnVm(cmd, vmData);
             }
         }
     }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/DvdDriveHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/DvdDriveHelper.cs
@@ -9,13 +9,22 @@ using System.Threading.Tasks;
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class DvdDriveHelper
+    public class DvdDriveHelper
     {
-        public static DvdDriveInfo Get(PowerShellManager powerShell, string vmName)
+        private PowerShellManager _powerShell;
+        private MiManager _mi;
+
+        public DvdDriveHelper(PowerShellManager powerShellManager, MiManager mi)
+        {
+            _powerShell = powerShellManager;
+            _mi = mi;
+        }
+
+        public DvdDriveInfo Get(string vmName)
         {
             DvdDriveInfo info = null;
 
-            PSObject result = GetPS(powerShell, vmName);
+            PSObject result = GetPS(vmName);
 
             if (result != null)
             {
@@ -30,13 +39,13 @@ namespace SolidCP.Providers.Virtualization
             return info;
         }
 
-        public static PSObject GetPS(PowerShellManager powerShell, string vmName)
+        public PSObject GetPS(string vmName)
         {
             Command cmd = new Command("Get-VMDvdDrive");
 
             cmd.Parameters.Add("VMName", vmName);
 
-            Collection<PSObject> result = powerShell.Execute(cmd, true);
+            Collection<PSObject> result = _powerShell.Execute(cmd, true);
 
             if (result != null && result.Count > 0)
             {
@@ -46,9 +55,9 @@ namespace SolidCP.Providers.Virtualization
             return null;
         }
 
-        public static void Set(PowerShellManager powerShell, string vmName, string path)
+        public void Set(string vmName, string path)
         {
-            var dvd = Get(powerShell, vmName);
+            var dvd = Get(vmName);
  
             Command cmd = new Command("Set-VMDvdDrive");
 
@@ -57,29 +66,29 @@ namespace SolidCP.Providers.Virtualization
             cmd.Parameters.Add("ControllerNumber", dvd.ControllerNumber);
             cmd.Parameters.Add("ControllerLocation", dvd.ControllerLocation);
 
-            powerShell.Execute(cmd, true);
+            _powerShell.Execute(cmd, true);
         }
 
-        public static void Update(PowerShellManager powerShell, VirtualMachine vm, bool dvdDriveShouldBeInstalled)
+        public void Update(VirtualMachine vm, bool dvdDriveShouldBeInstalled)
         {
             if (!vm.DvdDriveInstalled && dvdDriveShouldBeInstalled)
-                Add(powerShell, vm.Name);
+                Add(vm.Name);
             else if (vm.DvdDriveInstalled && !dvdDriveShouldBeInstalled)
-                Remove(powerShell, vm.Name);
+                Remove(vm.Name);
         }
 
-        public static void Add(PowerShellManager powerShell, string vmName)
+        public void Add(string vmName)
         {
             Command cmd = new Command("Add-VMDvdDrive");
 
             cmd.Parameters.Add("VMName", vmName);
 
-            powerShell.Execute(cmd, true, true);
+            _powerShell.Execute(cmd, true, true);
         }
 
-        public static void Remove(PowerShellManager powerShell, string vmName)
+        public void Remove(string vmName)
         {
-            var dvd = Get(powerShell, vmName);
+            var dvd = Get(vmName);
 
             Command cmd = new Command("Remove-VMDvdDrive");
 
@@ -87,7 +96,7 @@ namespace SolidCP.Providers.Virtualization
             cmd.Parameters.Add("ControllerNumber", dvd.ControllerNumber);
             cmd.Parameters.Add("ControllerLocation", dvd.ControllerLocation);
 
-            powerShell.Execute(cmd, true, true);
+            _powerShell.Execute(cmd, true, true);
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/FileSystemHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/FileSystemHelper.cs
@@ -1,0 +1,285 @@
+﻿using Microsoft.Management.Infrastructure;
+using SolidCP.Providers.HostedSolution;
+using SolidCP.Providers.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolidCP.Providers.Virtualization
+{
+    public class FileSystemHelper
+    {
+        private MiManager _miCim;
+        private string _serverName;
+
+        public FileSystemHelper(MiManager mi)
+        {
+            _serverName = mi.TargetComputer;
+            _miCim = new MiManager(mi, Constants.WMI_CIMV2_NAMESPACE);
+        }
+
+        public string ReadRemoteFile(string path)
+        {
+            // temp file name on "system" drive available through hidden share
+            string tempPath = Path.Combine(GetTempRemoteFolder(), Guid.NewGuid().ToString("N"));
+
+            HostedSolutionLog.LogInfo("Read remote file: " + path);
+            HostedSolutionLog.LogInfo("Local file temp path: " + tempPath);
+
+            // copy remote file to temp file (WMI)
+            if (!CopyFile(path, tempPath))
+                return null;
+
+            // read content of temp file
+            string remoteTempPath = ConvertToUNC(tempPath);
+            HostedSolutionLog.LogInfo("Remote file temp path: " + remoteTempPath);
+
+            string content = File.ReadAllText(remoteTempPath);
+
+            // delete temp file (WMI)
+            DeleteFile(tempPath);
+
+            return content;
+        }
+
+        public void WriteRemoteFile(string path, string content)
+        {
+            // temp file name on "system" drive available through hidden share
+            string tempPath = Path.Combine(GetTempRemoteFolder(), Guid.NewGuid().ToString("N"));
+
+            // write to temp file
+            string remoteTempPath = ConvertToUNC(tempPath);
+            File.WriteAllText(remoteTempPath, content);
+
+            // delete file (WMI)
+            if (FileExists(path))
+                DeleteFile(path);
+
+            // copy (WMI)
+            CopyFile(tempPath, path);
+
+            // delete temp file (WMI)
+            DeleteFile(tempPath);
+        }
+
+        public void DeleteFile(string path)
+        {
+            if (path.StartsWith(@"\\"))
+            {
+                // network share
+                File.Delete(path);
+            }
+            else
+            {
+                // delete file using WMI
+                CimInstance objFile = _miCim.GetCimInstance("CIM_Datafile", "Name='{0}'", path.Replace("\\", "\\\\"));
+                CimMethodResult result = _miCim.InvokeMethod(objFile, "Delete", null);
+                //check result?
+            }
+        }
+
+        public void DeleteFolder(string path)
+        {
+            if (path.StartsWith(@"\\"))
+            {
+                // network share
+                try
+                {
+                    FileUtils.DeleteFile(path);
+                }
+                catch { /* just skip */ }
+                FileUtils.DeleteFile(path);
+            }
+            else
+            {
+                // local folder
+                // delete sub folders first
+                CimInstance[] objSubFolders = GetSubFolders(path);
+                foreach (CimInstance objSubFolder in objSubFolders)
+                    DeleteFolder(objSubFolder.CimInstanceProperties["Name"].Value.ToString());
+
+                // delete this folder itself
+                CimInstance objFile = _miCim.GetCimInstance("Win32_Directory", "Name='{0}'", path.Replace("\\", "\\\\"));
+                _miCim.InvokeMethod(objFile, "Delete", null); //check result?
+            }
+        }
+
+        private CimInstance[] GetSubFolders(string path)
+        {
+            if (path.EndsWith("\\"))
+                path = path.Substring(0, path.Length - 1);
+
+            var directory = _miCim.GetCimInstance("Win32_Directory", "Name='{0}'", path.Replace("\\", "\\\\"));
+
+            return _miCim.EnumerateAssociatedInstances(directory, "Win32_Subdirectory", "Win32_Directory", "GroupComponent", "PartComponent");
+        }
+
+        public bool CopyFile(string sourceFileName, string destinationFileName)
+        {
+            HostedSolutionLog.LogInfo("Copy file - source: " + sourceFileName);
+            HostedSolutionLog.LogInfo("Copy file - destination: " + destinationFileName);
+
+            if (sourceFileName.StartsWith(@"\\")) // network share
+            {
+                if (!File.Exists(sourceFileName))
+                    return false;
+
+                File.Copy(sourceFileName, destinationFileName);
+            }
+            else
+            {
+                if (!FileExists(sourceFileName))
+                    return false;
+
+                CimInstance objFile = _miCim.GetCimInstance("CIM_DataFile", "Name = '{0}'", sourceFileName.Replace("\\", "\\\\"));
+                if (objFile == null)
+                    throw new Exception("Source file does not exists: " + sourceFileName);
+
+
+                var inParams = new CimMethodParametersCollection
+                    {
+                        CimMethodParameter.Create(
+                            "FileName",
+                            destinationFileName,
+                            CimType.String,
+                            CimFlags.In
+                        )
+                    };
+
+                CimMethodResult result = _miCim.InvokeMethod(objFile, "Copy", inParams);
+
+                if ((uint)result.ReturnValue.Value != 0)
+                    throw new Exception("Copy file failed: Result error: " + result.ReturnValue.Value.ToString());
+
+                //    // copy using WMI
+                //    Wmi cimv2 = new Wmi(ServerNameSettings, Constants.WMI_CIMV2_NAMESPACE);
+                //ManagementObject objFile = cimv2.GetWmiObject("CIM_Datafile", "Name='{0}'", sourceFileName.Replace("\\", "\\\\"));
+                //if (objFile == null)
+                //    throw new Exception("Source file does not exists: " + sourceFileName);
+
+                //objFile.InvokeMethod("Copy", new object[] { destinationFileName });
+            }
+            return true;
+        }
+
+        public bool FileExists(string path)
+        {
+            HostedSolutionLog.LogInfo("Check remote file exists: " + path);
+
+            if (path.StartsWith(@"\\")) // network share
+                return File.Exists(path);
+            else
+            {
+                CimInstance objDir = _miCim.GetCimInstance("CIM_Datafile", "Name='{0}'", path.Replace("\\", "\\\\"));
+                return (objDir != null);
+            }
+        }
+
+        public string ConvertToUNC(string path)
+        {
+            if (String.IsNullOrEmpty(_serverName)
+                || path.StartsWith(@"\\"))
+                return path;
+
+            return String.Format(@"\\{0}\{1}", _serverName, path.Replace(":", "$"));
+        }
+
+        public string GetTempRemoteFolder()
+        {
+            CimInstance objOS = _miCim.GetCimInstance("win32_OperatingSystem");
+            string sysPath = objOS.CimInstanceProperties["SystemDirectory"].Value.ToString();
+            // remove trailing slash
+            if (sysPath.EndsWith("\\"))
+                sysPath = sysPath.Substring(0, sysPath.Length - 1);
+
+            sysPath = sysPath.Substring(0, sysPath.LastIndexOf("\\") + 1) + "Temp";
+
+            return sysPath;
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            if (path.StartsWith(@"\\")) // network share
+                                        // TODO: That won't work with remote HyperV, unless network share added into domain.
+                                        // Need to check remotly
+                return Directory.Exists(path);
+            else
+            {
+                CimInstance objDir = _miCim.GetCimInstance("Win32_Directory", "Name='{0}'", path.Replace("\\", "\\\\"));
+                return (objDir != null);
+            }
+        }
+
+        public void CreateFolder(string path)
+        {
+            ExecuteRemoteProcess(String.Format("cmd.exe /c md \"{0}\"", path));
+        }
+
+        public bool ExecuteRemoteProcess(string command, bool terminateTimeoutProcess = false, TimeSpan? timeout = null)
+        {
+            return ExecuteRemoteProcessAsync(command, terminateTimeoutProcess, timeout).GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> ExecuteRemoteProcessAsync(string command, bool terminateTimeoutProcess = false, TimeSpan? timeout = null)
+        {
+            TimeSpan effectiveTimeout = timeout ?? TimeSpan.FromSeconds(20);
+
+            var methodParams = new CimMethodParametersCollection
+            {
+                CimMethodParameter.Create("CommandLine", command, Microsoft.Management.Infrastructure.CimType.String, CimFlags.In)
+            };
+
+            // run process
+            var createResult = await Task.Run(() => _miCim.InvokeStaticMethod("Win32_Process", "Create", methodParams));
+
+            uint returnValue = (uint)createResult.ReturnValue.Value;
+            if (returnValue != 0)
+            {
+                throw new InvalidOperationException($"Failed to create remote process. Win32_Process.Create returned error code: {returnValue}.");
+            }
+
+            uint processId = (uint)createResult.OutParameters["ProcessId"].Value;
+            if (processId == 0)
+            {
+                throw new InvalidOperationException("Win32_Process.Create executed successfully, but did not return a process identifier (ProcessId).");
+            }
+
+            // wait until finished (CIM has no event watcher so we will use polling)
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            while (stopwatch.Elapsed < effectiveTimeout)
+            {
+                var processInstance = await Task.Run(() => _miCim.GetCimInstance("Win32_Process", "ProcessId = {0}", processId));
+
+                if (processInstance == null)
+                {
+                    return true; // successfully finished
+                }
+
+                await Task.Delay(1000);
+            }
+
+            if (terminateTimeoutProcess)
+            {
+                await TryTerminateProcessAsync(processId);
+            }
+
+            return false; // process did not finish in time
+        }
+
+        private async Task TryTerminateProcessAsync(uint processId)
+        {
+            try
+            {
+                var processToKill = await Task.Run(() => _miCim.GetCimInstance("Win32_Process", "ProcessId = {0}", processId));
+                if (processToKill != null)
+                {
+                    await Task.Run(() => _miCim.InvokeMethod(processToKill, "Terminate"));
+                }
+            }
+            catch { }
+        }
+    }
+}

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
@@ -47,6 +47,18 @@ namespace SolidCP.Providers.Virtualization
             return result;
         }
 
+        public static JobResult CreateJobResultFromCimResults(MiManager mi, CimMethodResult outParams)
+        {
+            JobResult result = new JobResult();
+
+            result.ReturnValue = (ReturnCode)Convert.ToInt32(outParams.OutParameters["ReturnValue"].Value);
+            CimInstance objJob = outParams.OutParameters["Job"].Value as CimInstance;
+
+            result.Job = CreateFromCimObject(mi.GetInstance(objJob));
+
+            return result;
+        }
+
         public static JobResult CreateResultFromPSResults(Collection<PSObject> objJob)
         {
             if (objJob == null || objJob.Count == 0)
@@ -99,8 +111,9 @@ namespace SolidCP.Providers.Virtualization
             job.Caption = (string)objJob["Caption"].Value;
             job.Description = (string)objJob["Description"].Value;
             job.StartTime = (System.DateTime)objJob["StartTime"].Value;
-            // TODO proper parsing of WMI time spans, e.g. 00000000000001.325247:000
-            job.ElapsedTime = DateTime.Now; //wmi.ToDateTime((string)objJob["ElapsedTime"]);
+            // TODO CIM correcly provide ElapsedTime, e.g. 00000000000001.325247:000 so we can just use as it is.
+            //we can use after remove all WMIv1 stuff depencies. Need to change job.ElapsedTime type to TimeSpan.
+            job.ElapsedTime = DateTime.Now; //(System.TimeSpan)objJob["ElapsedTime"].Value;
             job.ErrorCode = Convert.ToInt32(objJob["ErrorCode"].Value);
             job.ErrorDescription = (string)objJob["ErrorDescription"].Value;
             job.PercentComplete = Convert.ToInt32(objJob["PercentComplete"].Value);

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
@@ -1,4 +1,5 @@
-﻿using SolidCP.Providers.HostedSolution;
+﻿using Microsoft.Management.Infrastructure;
+using SolidCP.Providers.HostedSolution;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -82,6 +83,27 @@ namespace SolidCP.Providers.Virtualization
             job.ErrorCode = Convert.ToInt32(objJob["ErrorCode"]);
             job.ErrorDescription = (string)objJob["ErrorDescription"];
             job.PercentComplete = Convert.ToInt32(objJob["PercentComplete"]);
+            return job;
+        }
+
+        public static ConcreteJob CreateFromCimObject(CimInstance cimJob)
+        {
+            if (cimJob == null || cimJob.CimInstanceProperties.Count == 0)
+                return null;
+
+            var objJob = cimJob.CimInstanceProperties;
+
+            ConcreteJob job = new ConcreteJob();
+            job.Id = (string)objJob["InstanceID"].Value;
+            job.JobState = (ConcreteJobState)Convert.ToInt32(objJob["JobState"].Value);
+            job.Caption = (string)objJob["Caption"].Value;
+            job.Description = (string)objJob["Description"].Value;
+            job.StartTime = (System.DateTime)objJob["StartTime"].Value;
+            // TODO proper parsing of WMI time spans, e.g. 00000000000001.325247:000
+            job.ElapsedTime = DateTime.Now; //wmi.ToDateTime((string)objJob["ElapsedTime"]);
+            job.ErrorCode = Convert.ToInt32(objJob["ErrorCode"].Value);
+            job.ErrorDescription = (string)objJob["ErrorDescription"].Value;
+            job.PercentComplete = Convert.ToInt32(objJob["PercentComplete"].Value);
             return job;
         }
 

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
@@ -52,9 +52,14 @@ namespace SolidCP.Providers.Virtualization
             JobResult result = new JobResult();
 
             result.ReturnValue = (ReturnCode)Convert.ToInt32(outParams.OutParameters["ReturnValue"].Value);
-            CimInstance objJob = outParams.OutParameters["Job"].Value as CimInstance;
+            try
+            {
+                CimInstance objJob = outParams.OutParameters["Job"].Value as CimInstance;
+                result.Job = CreateFromCimObject(mi.GetInstance(objJob));
 
-            result.Job = CreateFromCimObject(mi.GetInstance(objJob));
+            } catch (Exception e) {
+                HostedSolutionLog.LogError(e);
+            }
 
             return result;
         }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/JobHelper.cs
@@ -41,17 +41,19 @@ namespace SolidCP.Providers.Virtualization
             result.ReturnValue = (ReturnCode)Convert.ToInt32(outParams.OutParameters["ReturnValue"].Value);
             try
             {
-                CimInstance objJob = outParams.OutParameters["Job"].Value as CimInstance;
-                if (objJob == null)
-                { //we suppose if obj is null, then job already finished. Anyway ReturnValue should be checked first
-                    result.ReturnValue = ReturnCode.OK;
-                    result.Job = new ConcreteJob { 
-                        JobState = ConcreteJobState.New, 
-                        ErrorDescription = "The job has never been started"
-                    };
-                    return result;
-                }
-                result.Job = CreateFromCimObject(mi.GetInstance(objJob));
+                using (CimInstance objJob = outParams.OutParameters["Job"].Value as CimInstance)
+                {
+                    if (objJob == null)
+                    { //we suppose if obj is null, then job already finished. Anyway ReturnValue should be checked first
+                        result.Job = new ConcreteJob
+                        {
+                            JobState = ConcreteJobState.New,
+                            ErrorDescription = "The job has never been started"
+                        };
+                        return result;
+                    }
+                    result.Job = CreateFromCimObject(mi.GetInstance(objJob));
+                }                
 
             } catch (Exception e) {
                 HostedSolutionLog.LogError(e);

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/MemoryHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/MemoryHelper.cs
@@ -18,13 +18,12 @@ namespace SolidCP.Providers.Virtualization
             _powerShell = powerShellManager;
         }
 
-        public DynamicMemory GetDynamicMemory(PSObject vmObj)
+        public DynamicMemory GetDynamicMemory(VirtualMachineData vmData)
         {
             DynamicMemory info = null;
 
             Command cmd = new Command("Get-VMMemory");
-            cmd.Parameters.Add("VM", vmObj);
-            Collection<PSObject> result = _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+            Collection<PSObject> result = _powerShell.ExecuteOnVm(cmd, vmData);
 
             if (result != null && result.Count > 0)
             {
@@ -39,11 +38,10 @@ namespace SolidCP.Providers.Virtualization
             return info;
         }
 
-        public void Update(PSObject vmObj, int ramMb, DynamicMemory dynamicMemory)
+        public void Update(VirtualMachineData vmData, int ramMb, DynamicMemory dynamicMemory)
         {
             Command cmd = new Command("Set-VMMemory");
 
-            cmd.Parameters.Add("VM", vmObj);
             cmd.Parameters.Add("StartupBytes", ramMb * Constants.Size1M);
 
             if (dynamicMemory != null && dynamicMemory.Enabled)
@@ -59,7 +57,7 @@ namespace SolidCP.Providers.Virtualization
                 cmd.Parameters.Add("DynamicMemoryEnabled", false);
             }
 
-            _powerShell.Execute(cmd, false, true);
+            _powerShell.ExecuteOnVm(cmd, vmData, true);
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/ReplicaHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/ReplicaHelper.cs
@@ -2,9 +2,16 @@
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class ReplicaHelper
+    public class ReplicaHelper
     {
-        public static void SetReplicaServer(PowerShellManager powerShell, bool enabled, string remoteServer, string thumbprint, string storagePath)
+        private PowerShellManager _powerShell;
+
+        public ReplicaHelper(PowerShellManager powerShellManager)
+        {
+            _powerShell = powerShellManager;
+        }
+
+        public void SetReplicaServer(bool enabled, string remoteServer, string thumbprint, string storagePath)
         {
             Command cmd = new Command("Set-VMReplicationServer");
             cmd.Parameters.Add("ReplicationEnabled", enabled);
@@ -26,24 +33,24 @@ namespace SolidCP.Providers.Virtualization
                 cmd.Parameters.Add("DefaultStorageLocation", storagePath);
             }
 
-            powerShell.Execute(cmd, false);
+            _powerShell.Execute(cmd, false);
         }
 
-        public static void SetFirewallRule(PowerShellManager powerShell, bool enabled)
+        public void SetFirewallRule(bool enabled)
         {
             Command cmd = new Command("Enable-Netfirewallrule");
             cmd.Parameters.Add("DisplayName", "Hyper-V Replica HTTPS Listener (TCP-In)");
 
-            powerShell.Execute(cmd, false);
+            _powerShell.Execute(cmd, false);
         }
 
-        public static void RemoveVmReplication(PowerShellManager powerShell, string vmName, string server)
+        public void RemoveVmReplication(string vmName, string server)
         {
             Command cmd = new Command("Remove-VMReplication");
             cmd.Parameters.Add("VmName", vmName);
             if (!string.IsNullOrEmpty(server)) cmd.Parameters.Add("ComputerName", server);
 
-            powerShell.Execute(cmd, false);
+            _powerShell.Execute(cmd, false);
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
@@ -32,7 +32,7 @@ namespace SolidCP.Providers.Virtualization
             return snapshot;
         }
 
-        public static VirtualMachineSnapshot GetFromWmi(CimInstance objSnapshot)
+        public static VirtualMachineSnapshot GetFromCim(CimInstance objSnapshot)
         {
             if (objSnapshot == null || objSnapshot.CimInstanceProperties.Count == 0)
                 return null;

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Microsoft.Management.Infrastructure;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Management;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Text;
@@ -32,16 +32,16 @@ namespace SolidCP.Providers.Virtualization
             return snapshot;
         }
 
-        public static VirtualMachineSnapshot GetFromWmi(ManagementBaseObject objSnapshot)
+        public static VirtualMachineSnapshot GetFromWmi(CimInstance objSnapshot)
         {
-            if (objSnapshot == null || objSnapshot.Properties.Count == 0)
+            if (objSnapshot == null || objSnapshot.CimInstanceProperties.Count == 0)
                 return null;
 
             VirtualMachineSnapshot snapshot = new VirtualMachineSnapshot();
-            snapshot.Id = (string)objSnapshot["InstanceID"];
-            snapshot.Name = (string)objSnapshot["ElementName"];
+            snapshot.Id = (string)objSnapshot.CimInstanceProperties["InstanceID"].Value;
+            snapshot.Name = (string)objSnapshot.CimInstanceProperties["ElementName"].Value;
 
-            string parentId = (string)objSnapshot["Parent"];
+            string parentId = (string)objSnapshot.CimInstanceProperties["Parent"].Value;
             if (!String.IsNullOrEmpty(parentId))
             {
                 int idx = parentId.IndexOf("Microsoft:");
@@ -52,7 +52,7 @@ namespace SolidCP.Providers.Virtualization
             {
                 snapshot.Id = snapshot.Id.ToLower().Replace("microsoft:", "");
             }
-            snapshot.Created = Wmi.ToDateTime((string)objSnapshot["CreationTime"]);
+            snapshot.Created = (DateTime)objSnapshot.CimInstanceProperties["CreationTime"].Value;
 
             if (string.IsNullOrEmpty(snapshot.ParentId))
                 snapshot.ParentId = null; // for capability

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
@@ -9,9 +9,16 @@ using System.Threading.Tasks;
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class SnapshotHelper
+    public class SnapshotHelper
     {
-        public static VirtualMachineSnapshot GetFromPS(PSObject psObject, string runningSnapshotId = null)
+        private PowerShellManager _powerShell;
+
+        public SnapshotHelper(PowerShellManager powerShellManager)
+        {
+            _powerShell = powerShellManager;
+        }
+
+        public VirtualMachineSnapshot GetFromPS(PSObject psObject, string runningSnapshotId = null)
         {
             var snapshot = new VirtualMachineSnapshot
             {
@@ -32,7 +39,7 @@ namespace SolidCP.Providers.Virtualization
             return snapshot;
         }
 
-        public static VirtualMachineSnapshot GetFromCim(CimInstance objSnapshot)
+        public VirtualMachineSnapshot GetFromCim(CimInstance objSnapshot)
         {
             if (objSnapshot == null || objSnapshot.CimInstanceProperties.Count == 0)
                 return null;
@@ -60,22 +67,22 @@ namespace SolidCP.Providers.Virtualization
             return snapshot;
         }
 
-        public static void Delete(PowerShellManager powerShell, VirtualMachineSnapshot snapshot, bool includeChilds)
+        public void Delete(VirtualMachineSnapshot snapshot, bool includeChilds) //TODO: better to use VMObject instead of VMName ???
         {
             Command cmd = new Command("Remove-VMSnapshot");
             cmd.Parameters.Add("VMName", snapshot.VMName);
             cmd.Parameters.Add("Name", snapshot.Name);
             if (includeChilds) cmd.Parameters.Add("IncludeAllChildSnapshots", true);
 
-            powerShell.Execute(cmd, true);
+            _powerShell.Execute(cmd, true);
         }
 
-        public static void Delete(PowerShellManager powerShell, string vmName)
+        public void Delete(PSObject vmObj)
         {
             Command cmd = new Command("Remove-VMSnapshot");
-            cmd.Parameters.Add("VMName", vmName);
+            cmd.Parameters.Add("VM", vmObj);
 
-            powerShell.Execute(cmd, true);
+            _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/SnapshotHelper.cs
@@ -77,12 +77,11 @@ namespace SolidCP.Providers.Virtualization
             _powerShell.Execute(cmd, true);
         }
 
-        public void Delete(PSObject vmObj)
+        public void Delete(VirtualMachineData vmData)
         {
             Command cmd = new Command("Remove-VMSnapshot");
-            cmd.Parameters.Add("VM", vmObj);
 
-            _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+            _powerShell.ExecuteOnVm(cmd, vmData);
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VdsHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VdsHelper.cs
@@ -1,20 +1,96 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.IO;
-using System.Management;
-using System.Threading;
+﻿using Microsoft.Management.Infrastructure;
+using Microsoft.Management.Infrastructure.Generic;
 using Microsoft.Storage.Vds;
 using Microsoft.Storage.Vds.Advanced;
 using SolidCP.Providers.HostedSolution;
 using SolidCP.Providers.Virtualization.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Path = System.IO.Path;
+
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class VdsHelper
+    public class VdsHelper
     {
-        public static MountedDiskInfo GetMountedDiskInfo(string serverName, int driveNumber)
+        private MiManager _miCim;
+        private FileSystemHelper _fileSystemHelper;
+        private string _serverName;
+
+        public VdsHelper(MiManager mi, FileSystemHelper fileSystemHelper)
+        {
+            _serverName = mi.TargetComputer;
+            _miCim = new MiManager(mi, Constants.WMI_CIMV2_NAMESPACE);
+            _fileSystemHelper = fileSystemHelper;
+        }
+
+        public void ExpandDiskVolume(string diskAddress, string volumeName)
+        {
+            // find mounted disk using VDS
+            AdvancedDisk advancedDisk = null;
+            Pack diskPack = null;
+
+            FindVdsDisk(diskAddress, out advancedDisk, out diskPack);
+
+            if (advancedDisk == null)
+                throw new Exception("Could not find mounted disk");
+
+            // find volume
+            Volume diskVolume = null;
+            foreach (Volume volume in diskPack.Volumes)
+            {
+                if (volume.DriveLetter.ToString() == volumeName)
+                {
+                    diskVolume = volume;
+                    break;
+                }
+            }
+
+            if (diskVolume == null)
+                throw new Exception("Could not find disk volume: " + volumeName);
+
+            // determine maximum available space
+            ulong oneMegabyte = 1048576;
+            ulong freeSpace = 0;
+            foreach (DiskExtent extent in advancedDisk.Extents)
+            {
+                if (extent.Type != Microsoft.Storage.Vds.DiskExtentType.Free)
+                    continue;
+
+                if (extent.Size > oneMegabyte)
+                    freeSpace += extent.Size;
+            }
+
+            if (freeSpace == 0)
+                return;
+
+            // input disk
+            InputDisk inputDisk = new InputDisk();
+            foreach (VolumePlex plex in diskVolume.Plexes)
+            {
+                inputDisk.DiskId = advancedDisk.Id;
+                inputDisk.Size = freeSpace;
+                inputDisk.PlexId = plex.Id;
+
+                foreach (DiskExtent extent in plex.Extents)
+                    inputDisk.MemberIndex = extent.MemberIndex;
+
+                break;
+            }
+
+            // extend volume
+            Async extendEvent = diskVolume.BeginExtend(new InputDisk[] { inputDisk }, null, null);
+            while (!extendEvent.IsCompleted)
+                System.Threading.Thread.Sleep(100);
+            diskVolume.EndExtend(extendEvent);
+        }
+
+        public MountedDiskInfo GetMountedDiskInfo(int driveNumber)
         {
             MountedDiskInfo diskInfo = new MountedDiskInfo { DiskNumber = driveNumber };
 
@@ -25,14 +101,14 @@ namespace SolidCP.Providers.Virtualization
             // first attempt
             Thread.Sleep(3000);
             HostedSolutionLog.LogInfo("Trying to find mounted disk - first attempt");
-            FindVdsDisk(serverName, diskInfo.DiskNumber, out advancedDisk, out diskPack);
+            FindVdsDisk(diskInfo.DiskNumber, out advancedDisk, out diskPack);
 
             // second attempt
             if (advancedDisk == null)
             {
                 Thread.Sleep(20000);
                 HostedSolutionLog.LogInfo("Trying to find mounted disk - second attempt");
-                FindVdsDisk(serverName, diskInfo.DiskNumber, out advancedDisk, out diskPack);
+                FindVdsDisk(diskInfo.DiskNumber, out advancedDisk, out diskPack);
             }
 
             if (advancedDisk == null)
@@ -51,24 +127,27 @@ namespace SolidCP.Providers.Virtualization
                 useDiskPartToClearReadOnly = Boolean.Parse(ConfigurationManager.AppSettings[Constants.CONFIG_USE_DISKPART_TO_CLEAR_READONLY_FLAG]);
 
             // determine disk index for DiskPart
-            Wmi cimv2 = new Wmi(serverName, Constants.WMI_CIMV2_NAMESPACE);
-            ManagementObject objDisk = cimv2.GetWmiObject("win32_diskdrive",
-                "Model='Msft Virtual Disk SCSI Disk Device' and ScsiTargetID={0} and ScsiLogicalUnit={1} and scsiPort={2}",
-                targetId, lun, portNumber);
+            CimInstance objDisk = _miCim.GetCimInstanceWithSelect(
+                    "win32_diskdrive",
+                    "Index", // Select only "Index"
+                    "Model='Msft Virtual Disk SCSI Disk Device' and ScsiTargetID={0} and ScsiLogicalUnit={1} and scsiPort={2}",
+                    targetId, lun, portNumber
+                );
 
             if (useDiskPartToClearReadOnly)
             {
                 // *** Clear Read-Only and bring disk online with DiskPart ***
                 HostedSolutionLog.LogInfo("Clearing disk Read-only flag and bringing disk online");
 
-                if (objDisk != null)
+                if (objDisk != null && objDisk.CimInstanceProperties["Index"]?.Value != null)
                 {
                     // disk found
                     // run DiskPart
-                    string diskPartResult = RunDiskPart(serverName, String.Format(@"select disk {0}
-attributes disk clear readonly
-online disk
-exit", Convert.ToInt32(objDisk["Index"])));
+                    string diskPartResult = RunDiskPart(
+                        String.Format(@"select disk {0}
+                                        attributes disk clear readonly
+                                        online disk
+                                        exit", Convert.ToInt32(objDisk.CimInstanceProperties["Index"].Value)));
 
                     HostedSolutionLog.LogInfo("DiskPart Result: " + diskPartResult);
                 }
@@ -105,7 +184,7 @@ exit", Convert.ToInt32(objDisk["Index"])));
             Thread.Sleep(3000);
 
             // get disk again
-            FindVdsDisk(serverName, diskInfo.DiskNumber, out advancedDisk, out diskPack);
+            FindVdsDisk(diskInfo.DiskNumber, out advancedDisk, out diskPack);
 
             // find volumes using VDS
             List<string> volumes = new List<string>();
@@ -121,11 +200,16 @@ exit", Convert.ToInt32(objDisk["Index"])));
             if (volumes.Count == 0 && objDisk != null)
             {
                 HostedSolutionLog.LogInfo("Querying disk volumes with WMI");
-                foreach (ManagementObject objPartition in objDisk.GetRelated("Win32_DiskPartition"))
+                var partitions = _miCim.EnumerateAssociatedInstances(objDisk, "Win32_DiskDriveToDiskPartition", "Win32_DiskPartition");
+                foreach (var objPartition in partitions)
                 {
-                    foreach (ManagementObject objVolume in objPartition.GetRelated("Win32_LogicalDisk"))
+                    var logicalDisks = _miCim.EnumerateAssociatedInstances(objPartition, "Win32_LogicalDiskToPartition", "Win32_LogicalDisk");
+                    foreach (var objVolume in logicalDisks)
                     {
-                        volumes.Add(objVolume["Name"].ToString().TrimEnd(':'));
+                        if (objVolume.CimInstanceProperties["Name"]?.Value != null)
+                        {
+                            volumes.Add(objVolume.CimInstanceProperties["Name"].Value.ToString().TrimEnd(':'));
+                        }
                     }
                 }
             }
@@ -138,24 +222,25 @@ exit", Convert.ToInt32(objDisk["Index"])));
             return diskInfo;
         }
 
-        public static void FindVdsDisk(string serverName, int driveNumber, out AdvancedDisk advancedDisk, out Pack diskPack)
+        public void FindVdsDisk(int driveNumber, out AdvancedDisk advancedDisk, out Pack diskPack)
         {
             Func<Disk, bool> compareFunc =  disk => disk.Name.EndsWith("PhysicalDrive" + driveNumber);
-            FindVdsDisk(serverName, compareFunc, out advancedDisk, out diskPack);
-        }
-        public static void FindVdsDisk(string serverName, string diskAddress, out AdvancedDisk advancedDisk, out Pack diskPack)
-        {
-            Func<Disk, bool> compareFunc =  disk => disk.DiskAddress == diskAddress;
-            FindVdsDisk(serverName, compareFunc, out advancedDisk, out diskPack);
+            FindVdsDisk(compareFunc, out advancedDisk, out diskPack);
         }
 
-        private static void FindVdsDisk(string serverName, Func<Disk, bool> compareFunc, out AdvancedDisk advancedDisk, out Pack diskPack)
+        public void FindVdsDisk(string diskAddress, out AdvancedDisk advancedDisk, out Pack diskPack)
+        {
+            Func<Disk, bool> compareFunc =  disk => disk.DiskAddress == diskAddress;
+            FindVdsDisk(compareFunc, out advancedDisk, out diskPack);
+        }
+
+        private void FindVdsDisk(Func<Disk, bool> compareFunc, out AdvancedDisk advancedDisk, out Pack diskPack)
         {
             advancedDisk = null;
             diskPack = null;
 
             ServiceLoader serviceLoader = new ServiceLoader();
-            Service vds = serviceLoader.LoadService(serverName);
+            Service vds = serviceLoader.LoadService(_serverName);
             vds.WaitForServiceReady();
 
             foreach (Disk disk in vds.UnallocatedDisks)
@@ -185,17 +270,17 @@ exit", Convert.ToInt32(objDisk["Index"])));
         }
 
         // obsolete and currently is not used
-        private static string RunDiskPart(string serverName, string script)
+        private string RunDiskPart(string script)
         {
             // create temp script file name
-            string localPath = Path.Combine(GetTempRemoteFolder(serverName), Guid.NewGuid().ToString("N"));
+            string localPath = Path.Combine(_fileSystemHelper.GetTempRemoteFolder(), Guid.NewGuid().ToString("N"));
 
             // save script to remote temp file
-            string remotePath = ConvertToUNC(serverName, localPath);
+            string remotePath = _fileSystemHelper.ConvertToUNC(localPath);
             File.AppendAllText(remotePath, script);
 
             // run diskpart
-            ExecuteRemoteProcess(serverName, "DiskPart /s " + localPath);
+            _fileSystemHelper.ExecuteRemoteProcess("DiskPart /s " + localPath);
 
             // delete temp script
             try
@@ -210,85 +295,61 @@ exit", Convert.ToInt32(objDisk["Index"])));
             return "";
         }
 
-        public static string ConvertToUNC(string serverName, string path)
-        {
-            if (String.IsNullOrEmpty(serverName)
-                || path.StartsWith(@"\\"))
-                return path;
+        //public static void ExecuteRemoteProcess(string serverName, string command)
+        //{
+        //    Wmi cimv2 = new Wmi(serverName, "root\\cimv2");
+        //    ManagementClass objProcess = cimv2.GetWmiClass("Win32_Process");
 
-            return String.Format(@"\\{0}\{1}", serverName, path.Replace(":", "$"));
-        }
+        //    // run process
+        //    object[] methodArgs = { command, null, null, 0 };
+        //    objProcess.InvokeMethod("Create", methodArgs);
 
-        public static string GetTempRemoteFolder(string serverName)
-        {
-            Wmi cimv2 = new Wmi(serverName, "root\\cimv2");
-            ManagementObject objOS = cimv2.GetWmiObject("win32_OperatingSystem");
-            string sysPath = (string)objOS["SystemDirectory"];
+        //    // process ID
+        //    int processId = Convert.ToInt32(methodArgs[3]);
 
-            // remove trailing slash
-            if (sysPath.EndsWith("\\"))
-                sysPath = sysPath.Substring(0, sysPath.Length - 1);
+        //    // wait until finished
+        //    // Create event query to be notified within 1 second of 
+        //    // a change in a service
+        //    WqlEventQuery query =
+        //        new WqlEventQuery("__InstanceDeletionEvent",
+        //        new TimeSpan(0, 0, 1),
+        //        "TargetInstance isa \"Win32_Process\"");
 
-            sysPath = sysPath.Substring(0, sysPath.LastIndexOf("\\") + 1) + "Temp";
+        //    // Initialize an event watcher and subscribe to events 
+        //    // that match this query
+        //    ManagementEventWatcher watcher = new ManagementEventWatcher(cimv2.GetScope(), query);
+        //    // times out watcher.WaitForNextEvent in 20 seconds
+        //    watcher.Options.Timeout = new TimeSpan(0, 0, 20);
 
-            return sysPath;
-        }
+        //    // Block until the next event occurs 
+        //    // Note: this can be done in a loop if waiting for 
+        //    //        more than one occurrence
+        //    while (true)
+        //    {
+        //        ManagementBaseObject e = null;
 
-        public static void ExecuteRemoteProcess(string serverName, string command)
-        {
-            Wmi cimv2 = new Wmi(serverName, "root\\cimv2");
-            ManagementClass objProcess = cimv2.GetWmiClass("Win32_Process");
+        //        try
+        //        {
+        //            // wait untill next process finish
+        //            e = watcher.WaitForNextEvent();
+        //        }
+        //        catch
+        //        {
+        //            // nothing has been finished in timeout period
+        //            return; // exit
+        //        }
 
-            // run process
-            object[] methodArgs = { command, null, null, 0 };
-            objProcess.InvokeMethod("Create", methodArgs);
+        //        // check process id
+        //        int pid = Convert.ToInt32(((ManagementBaseObject)e["TargetInstance"])["ProcessID"]);
+        //        if (pid == processId)
+        //        {
+        //            //Cancel the subscription
+        //            watcher.Stop();
 
-            // process ID
-            int processId = Convert.ToInt32(methodArgs[3]);
-
-            // wait until finished
-            // Create event query to be notified within 1 second of 
-            // a change in a service
-            WqlEventQuery query =
-                new WqlEventQuery("__InstanceDeletionEvent",
-                new TimeSpan(0, 0, 1),
-                "TargetInstance isa \"Win32_Process\"");
-
-            // Initialize an event watcher and subscribe to events 
-            // that match this query
-            ManagementEventWatcher watcher = new ManagementEventWatcher(cimv2.GetScope(), query);
-            // times out watcher.WaitForNextEvent in 20 seconds
-            watcher.Options.Timeout = new TimeSpan(0, 0, 20);
-
-            // Block until the next event occurs 
-            // Note: this can be done in a loop if waiting for 
-            //        more than one occurrence
-            while (true)
-            {
-                ManagementBaseObject e = null;
-
-                try
-                {
-                    // wait untill next process finish
-                    e = watcher.WaitForNextEvent();
-                }
-                catch
-                {
-                    // nothing has been finished in timeout period
-                    return; // exit
-                }
-
-                // check process id
-                int pid = Convert.ToInt32(((ManagementBaseObject)e["TargetInstance"])["ProcessID"]);
-                if (pid == processId)
-                {
-                    //Cancel the subscription
-                    watcher.Stop();
-
-                    // exit
-                    return;
-                }
-            }
-        }
+        //            // exit
+        //            return;
+        //        }
+        //    }
+        //}
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -81,7 +81,7 @@ namespace SolidCP.Providers.Virtualization
                 }                
             }            
         }
-
+                
         public PSObject GetVmPSObject(string vmId) //if any Powershell command accept VM object WE MUST use it as it extremely faster
         {
             Command cmd = new Command("Get-VM");

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -167,7 +167,18 @@ namespace SolidCP.Providers.Virtualization
             return str;
         }
 
-        public int GetVMProcessors(string name)
+        public int GetVMProcessors(string vmId)
+        {
+            int procs = 0;
+            using(CimInstance vmSettings = GetVirtualMachineSettingsObject(vmId))
+            using(CimInstance cimSummary = GetSummaryInformation(vmSettings, SummaryInformationRequest.NumberOfProcessors))
+            {
+                procs = Convert.ToInt32(cimSummary.CimInstanceProperties["NumberOfProcessors"].Value);                
+            }
+            return procs;
+        }
+
+        public int GetVMProcessorsPS(string name) //22 time slower than CIM GetVMProcessors
         {
             int procs = 0;
 

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -206,20 +206,19 @@ namespace SolidCP.Providers.Virtualization
             return procs;
         }
 
-        public void UpdateProcessors(PSObject vmObj, int cpuCores, int cpuLimitSettings, int cpuReserveSettings, int cpuWeightSettings)
+        public void UpdateProcessors(VirtualMachineData vmData, int cpuCores, int cpuLimitSettings, int cpuReserveSettings, int cpuWeightSettings)
         {
             Command cmd = new Command("Set-VMProcessor");
 
-            cmd.Parameters.Add("VM", vmObj);
             cmd.Parameters.Add("Count", cpuCores);
             cmd.Parameters.Add("Maximum", cpuLimitSettings);
             cmd.Parameters.Add("Reserve", cpuReserveSettings);
             cmd.Parameters.Add("RelativeWeight", cpuWeightSettings);
 
-            _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+            _powerShell.ExecuteOnVm(cmd, vmData);
         }
 
-        public void Delete(PSObject vmObj, string vmId, string clusterName)
+        public void Delete(VirtualMachineData vmData, string vmId, string clusterName)
         {
             if (!String.IsNullOrEmpty(clusterName))
             {
@@ -230,28 +229,25 @@ namespace SolidCP.Providers.Virtualization
                 _powerShell.Execute(cmdCluster, false);
             }
             Command cmd = new Command("Remove-VM");
-            cmd.Parameters.Add("VM", vmObj);
             cmd.Parameters.Add("Force");
-            _powerShell.Execute(cmd, false, true); //False, because all remote connection information is already contained in vmObj
+            _powerShell.ExecuteOnVm(cmd, vmData, true);
         }
 
-        public void Stop(PSObject vmObj, bool force)
+        public void Stop(VirtualMachineData vmData, bool force)
         {
             Command cmd = new Command("Stop-VM");
 
-            cmd.Parameters.Add("VM", vmObj);
             if (force) cmd.Parameters.Add("Force");
             //if (!string.IsNullOrEmpty(reason)) cmd.Parameters.Add("Reason", reason);
             try
             {
-                _powerShell.Execute(cmd, false, true);
+                _powerShell.ExecuteOnVm(cmd, vmData, true);
             }
             catch
             {
                 cmd = new Command("Stop-VM");
-                cmd.Parameters.Add("VM", vmObj);
                 cmd.Parameters.Add("TurnOff");
-                _powerShell.Execute(cmd, false); //False, because all remote connection information is already contained in vmObj
+                _powerShell.ExecuteOnVm(cmd, vmData);
             }
             
         }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.Management.Infrastructure;
+using SolidCP.Providers.HostedSolution;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -10,9 +12,99 @@ using System.Threading.Tasks;
 
 namespace SolidCP.Providers.Virtualization
 {
-    public static class VirtualMachineHelper
+    public class VirtualMachineHelper
     {
-        public static OperationalStatus GetVMHeartBeatStatus(PowerShellManager powerShell, string name)
+        private PowerShellManager _powerShell;
+        private MiManager _mi;
+        public VirtualMachineHelper(PowerShellManager powerShellManager, MiManager mi)
+        {
+            _powerShell = powerShellManager;
+            _mi = mi;
+        }
+
+        public static VirtualMachine CreateVirtualMachineFromCimInstance(CimInstance cimInsVm)
+        {
+            if (cimInsVm == null || cimInsVm.CimInstanceProperties.Count == 0)
+                return null;
+
+            var objVm = cimInsVm.CimInstanceProperties;
+
+            VirtualMachine vm = new VirtualMachine();
+            vm.VirtualMachineId = (string)objVm["Name"].Value;
+            vm.Name = (string)objVm["ElementName"].Value;
+            vm.State = (VirtualMachineState)Convert.ToInt32(objVm["EnabledState"].Value);
+            vm.Status = Convert.ToString(objVm["Status"].Value);
+            vm.Uptime = Convert.ToInt64(objVm["OnTimeInMilliseconds"].Value);
+            return vm;
+        }
+
+        public CimInstance GetSummaryInformation(string vmId, params SummaryInformationRequest[] requestedInformation)
+        {
+            if (string.IsNullOrWhiteSpace(vmId)) {
+                HostedSolutionLog.LogWarning("VM identifier cannot be empty.", nameof(vmId));
+            }
+            if (requestedInformation == null || requestedInformation.Length == 0) {
+                HostedSolutionLog.LogWarning("At least one SummaryInformationRequest must be provided.", nameof(requestedInformation));
+            }
+
+            CimInstance managementService = _mi.GetCimInstance("Msvm_VirtualSystemManagementService");
+            if (managementService == null) {
+                HostedSolutionLog.LogWarning("Failed to retrieve Msvm_VirtualSystemManagementService instance.");
+            }
+
+            uint[] reqif = new uint[requestedInformation.Length];
+            for (int i = 0; i < requestedInformation.Length; i++)
+                reqif[i] = (uint)requestedInformation[i];
+
+            CimInstance vmInstance = _mi.GetCimInstance("Msvm_ComputerSystem", "Name = '{0}'", vmId);
+            CimInstance settingData = _mi.GetAssociatedCimInstance(vmInstance, "Msvm_VirtualSystemSettingData", "Msvm_SettingsDefineState"); //Optimizated query
+            //CimInstance settingData = GetCimInstance("Msvm_VirtualSystemSettingData", "InstanceID Like 'Microsoft:{0}%'", vmId); //this is slower ~6 times that two the above query
+            
+            if (settingData == null)
+                HostedSolutionLog.LogWarning($"Virtual machine with ID '{vmId}' not found.");
+
+            var inParams = new CimMethodParametersCollection
+            {
+                CimMethodParameter.Create("SettingData", new CimInstance[] { settingData }, CimType.ReferenceArray, CimFlags.None),
+                CimMethodParameter.Create("RequestedInformation", reqif, CimFlags.None),
+            };
+
+            CimMethodResult result = _mi.InvokeMethod(managementService, "GetSummaryInformation", inParams);
+
+            if (result.ReturnValue.Value is uint retVal && retVal != 0){
+                HostedSolutionLog.LogError(new Exception($"GetSummaryInformation returned error code: {retVal}"));
+            }
+
+            object summaryObj = result.OutParameters["SummaryInformation"].Value;
+            if (summaryObj is CimInstance[] summaryArray)
+            {
+                return summaryArray.FirstOrDefault();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public OperationalStatus GetVMHeartBeatStatusFromGetVmResult(Collection<PSObject> result, string name)
+        {
+            OperationalStatus status = OperationalStatus.None;
+            try
+            {
+                var statusString = TryToGetStatusString(result, "PrimaryOperationalStatus");
+                status = (OperationalStatus)Enum.Parse(typeof(OperationalStatus), statusString);
+            }
+            catch
+            {
+                HostedSolution.HostedSolutionLog.LogWarning("GetVMHeartBeatStatus: can not get OperationalStatus from Get-VM result");
+                status = GetVMHeartBeatStatus("PrimaryStatusDescription"); //try to get it again, but from Get-VMIntegrationService
+            }
+
+            return status;
+
+        }
+
+        public OperationalStatus GetVMHeartBeatStatus(string name)
         {
             OperationalStatus status = OperationalStatus.None;
 
@@ -21,7 +113,7 @@ namespace SolidCP.Providers.Virtualization
             cmd.Parameters.Add("VMName", name);
             cmd.Parameters.Add("Name", "HeartBeat");
 
-            Collection<PSObject> result = powerShell.Execute(cmd, true);
+            Collection<PSObject> result = _powerShell.Execute(cmd, true);
             if (result != null && result.Count > 0)
             {
                 //var statusString = result[0].GetProperty("PrimaryOperationalStatus");
@@ -33,7 +125,7 @@ namespace SolidCP.Providers.Virtualization
             return status;
         }
 
-        private static string TryToGetStatusString(Collection<PSObject> result, string propertyName, bool isLast = false) //burn in hell MS for your bugs!
+        private string TryToGetStatusString(Collection<PSObject> result, string propertyName, bool isLast = false) //burn in hell MS for your bugs!
         {
             string status = null;
             try
@@ -53,7 +145,7 @@ namespace SolidCP.Providers.Virtualization
             return status;
         }
 
-        private static string ConvertToOperationalStatusTypeString(string str)
+        private string ConvertToOperationalStatusTypeString(string str)
         {
             switch (str)
             {
@@ -80,7 +172,7 @@ namespace SolidCP.Providers.Virtualization
             return str;
         }
 
-        public static int GetVMProcessors(PowerShellManager powerShell, string name)
+        public int GetVMProcessors(string name)
         {
             int procs = 0;
 
@@ -88,7 +180,7 @@ namespace SolidCP.Providers.Virtualization
 
             cmd.Parameters.Add("VMName", name);
 
-            Collection<PSObject> result = powerShell.Execute(cmd, true);
+            Collection<PSObject> result = _powerShell.Execute(cmd, true);
             if (result != null && result.Count > 0)
             {
                 procs = Convert.ToInt32(result[0].GetProperty("Count"));
@@ -97,7 +189,7 @@ namespace SolidCP.Providers.Virtualization
             return procs;
         }
 
-        public static void UpdateProcessors(PowerShellManager powerShell, VirtualMachine vm, int cpuCores, int cpuLimitSettings, int cpuReserveSettings, int cpuWeightSettings)
+        public void UpdateProcessors(VirtualMachine vm, int cpuCores, int cpuLimitSettings, int cpuReserveSettings, int cpuWeightSettings)
         {
             Command cmd = new Command("Set-VMProcessor");
 
@@ -107,10 +199,10 @@ namespace SolidCP.Providers.Virtualization
             cmd.Parameters.Add("Reserve", cpuReserveSettings);
             cmd.Parameters.Add("RelativeWeight", cpuWeightSettings);
 
-            powerShell.Execute(cmd, true);
+            _powerShell.Execute(cmd, true);
         }
 
-        public static void Delete(PowerShellManager powerShell, string vmName, string vmId, string server, string clusterName)
+        public void Delete(string vmName, string vmId, string clusterName)
         {
             if (!String.IsNullOrEmpty(clusterName))
             {
@@ -118,34 +210,107 @@ namespace SolidCP.Providers.Virtualization
                 cmdCluster.Parameters.Add("VMId", vmId);
                 cmdCluster.Parameters.Add("RemoveResources");
                 cmdCluster.Parameters.Add("Force");
-                powerShell.Execute(cmdCluster, false);
+                _powerShell.Execute(cmdCluster, false);
             }
             Command cmd = new Command("Remove-VM");
             cmd.Parameters.Add("Name", vmName);
-            if (!string.IsNullOrEmpty(server)) cmd.Parameters.Add("ComputerName", server);
             cmd.Parameters.Add("Force");
-            powerShell.Execute(cmd, false, true);
+            _powerShell.Execute(cmd, true, true);
         }
-        public static void Stop(PowerShellManager powerShell, string vmName, bool force, string server)
+
+        public void Stop(string vmName, bool force)
         {
             Command cmd = new Command("Stop-VM");
 
             cmd.Parameters.Add("Name", vmName);
             if (force) cmd.Parameters.Add("Force");
-            if (!string.IsNullOrEmpty(server)) cmd.Parameters.Add("ComputerName", server);
             //if (!string.IsNullOrEmpty(reason)) cmd.Parameters.Add("Reason", reason);
             try
             {
-                powerShell.Execute(cmd, false, true);
+                _powerShell.Execute(cmd, true, true);
             }
             catch
             {
                 cmd = new Command("Stop-VM");
                 cmd.Parameters.Add("Name", vmName);
                 cmd.Parameters.Add("TurnOff");
-                powerShell.Execute(cmd, false);
+                _powerShell.Execute(cmd);
             }
             
+        }
+
+        protected VirtualMachine GetVirtualMachineCim(string vmId, bool extendedInfo) //examples of MI
+        {
+            CimInstance cimVm = _mi.GetCimInstanceWithSelect(
+                "Msvm_ComputerSystem",
+                "Name, ElementName, EnabledState, Status, OnTimeInMilliseconds",
+                "Name = '{0}'", vmId); //Name = "GUID"
+            VirtualMachine vm = VirtualMachineHelper.CreateVirtualMachineFromCimInstance(cimVm);
+
+            if (vm != null)
+            {
+                CimInstance cimSettings = _mi.GetAssociatedCimInstance(cimVm, "Msvm_VirtualSystemSettingData", "Msvm_SettingsDefineState");
+                var objSettings = cimSettings.CimInstanceProperties;
+
+                CimInstance cimSummary = GetSummaryInformation(vmId,
+                    SummaryInformationRequest.Heartbeat,
+                    SummaryInformationRequest.MemoryUsage,
+                    SummaryInformationRequest.ProcessorLoad,
+                    SummaryInformationRequest.NumberOfProcessors);
+                var objSummary = cimSummary.CimInstanceProperties;
+
+                vm.CpuUsage = Convert.ToInt32(objSummary["ProcessorLoad"].Value);
+                vm.Version = Convert.ToString(objSettings["Version"].Value);
+
+                if (Convert.ToDouble(vm.Version) > Convert.ToDouble(Constants.ConfigurationVersion))
+                    vm.RamUsage = Convert.ToInt32(Convert.ToUInt64(objSummary["MemoryUsage"].Value) / Constants.Size1M);
+                else
+                    vm.RamUsage = Convert.ToInt32(Convert.ToUInt64(objSummary["MemoryAvailable"].Value) / Constants.Size1M);
+
+                CimInstance cimRamInfo = _mi.GetCimInstanceWithSelect(
+                    "Msvm_MemorySettingData",
+                    "VirtualQuantity",
+                    "InstanceID Like 'Microsoft:{0}%'", vmId);
+                var ramInfo = cimRamInfo.CimInstanceProperties;
+                vm.RamSize = Convert.ToInt32(ramInfo["VirtualQuantity"].Value);
+
+                bool isDynamicMemoryEnabled = Convert.ToBoolean(ramInfo["DynamicMemoryEnabled"].Value);
+
+                vm.Generation = Convert.ToString(objSettings["VirtualSystemSubType"].Value).EndsWith(":2") ? 2 : 1;
+                vm.ProcessorCount = Convert.ToInt32(objSummary["NumberOfProcessors"].Value);
+
+                string parentRelPath = Convert.ToString(objSettings["Parent"].Value);
+                if (!string.IsNullOrEmpty(parentRelPath))
+                {
+                    vm.ParentSnapshotId = parentRelPath.Split(new[] { "InstanceID=\"" }, StringSplitOptions.None)[1].Split('"')[0].Split(':')[1];
+                }
+
+                vm.Heartbeat = (OperationalStatus)Convert.ToInt32(objSummary["Heartbeat"].Value);
+                vm.CreatedDate = (System.DateTime)objSettings["CreationTime"].Value;
+
+                vm.ReplicationState = (ReplicationState)Convert.ToInt32(objSummary["ReplicationState"].Value);
+
+                //var commands = new List<Command>
+                //{
+                //    new Command("Get-VM") { Parameters = { { "Id", vmId } } },
+                //    new Command("Select-Object") { Parameters = { { "Property", new string[] { "IsClustered" } } } }
+                //};
+                //Collection<PSObject> result = PowerShell.Execute(commands, true);
+                //vm.IsClustered = result[0].GetBool("IsClustered");
+
+                //if (extendedInfo)
+                //{
+
+                //}
+
+                //if (isDynamicMemoryEnabled)
+                //{
+                //    vm.DynamicMemory = MemoryHelper.GetDynamicMemory(PowerShell, vm.Name);
+                //}
+
+            }
+
+            return vm;
         }
     }
 }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -114,14 +114,20 @@ namespace SolidCP.Providers.Virtualization
 
         public OperationalStatus GetVMHeartBeatStatus(string vmId)
         {
-            HostedSolution.HostedSolutionLog.LogWarning("GetVMHeartBeatStatus: oj oj oj");
             OperationalStatus status = OperationalStatus.None;
-
-            using (CimInstance vmSettings = GetVirtualMachineSettingsObject(vmId))
-            using (CimInstance cimSummary = GetSummaryInformation(vmSettings, SummaryInformationRequest.Heartbeat))
+            try
             {
-                status = (OperationalStatus)Convert.ToInt32(cimSummary.CimInstanceProperties["Heartbeat"].Value);
+                using (CimInstance vmSettings = GetVirtualMachineSettingsObject(vmId))
+                using (CimInstance cimSummary = GetSummaryInformation(vmSettings, SummaryInformationRequest.Heartbeat))
+                {
+                    status = (OperationalStatus)Convert.ToInt32(cimSummary.CimInstanceProperties["Heartbeat"].Value);
+                }
             }
+            catch
+            {
+                //Nothing to do here — the panel works so fast that we can even get an exception while fetching the VM Heartbeat :D
+            }
+
             return status;
         }
 

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/VirtualMachineHelper.cs
@@ -22,7 +22,7 @@ namespace SolidCP.Providers.Virtualization
             _mi = mi;
         }
 
-        public static VirtualMachine CreateVirtualMachineFromCimInstance(CimInstance cimInsVm)
+        public VirtualMachine CreateVirtualMachineFromCimInstance(CimInstance cimInsVm)
         {
             if (cimInsVm == null || cimInsVm.CimInstanceProperties.Count == 0)
                 return null;
@@ -245,7 +245,7 @@ namespace SolidCP.Providers.Virtualization
                 "Msvm_ComputerSystem",
                 "Name, ElementName, EnabledState, Status, OnTimeInMilliseconds",
                 "Name = '{0}'", vmId); //Name = "GUID"
-            VirtualMachine vm = VirtualMachineHelper.CreateVirtualMachineFromCimInstance(cimVm);
+            VirtualMachine vm = this.CreateVirtualMachineFromCimInstance(cimVm);
 
             if (vm != null)
             {

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
@@ -2756,12 +2756,16 @@ namespace SolidCP.Providers.Virtualization
         public bool DirectoryExists(string path)
         {
             if (path.StartsWith(@"\\")) // network share
+                                        // TODO: That won't work with remote HyperV, unless network share added into domain.
+                                        // Need to check remotly
                 return Directory.Exists(path);
             else
             {
-                Wmi cimv2 = new Wmi(ServerNameSettings, Constants.WMI_CIMV2_NAMESPACE);
-                ManagementObject objDir = cimv2.GetWmiObject("Win32_Directory", "Name='{0}'", path.Replace("\\", "\\\\"));
-                return (objDir != null);
+                using (var cim = new MiManager(mi, Constants.WMI_CIMV2_NAMESPACE)) //because change namespace
+                {
+                    CimInstance objDir = cim.GetCimInstance("Win32_Directory", "Name='{0}'", path.Replace("\\", "\\\\"));
+                    return (objDir != null);
+                }
             }
         }
 

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
@@ -1612,7 +1612,6 @@ namespace SolidCP.Providers.Virtualization
                         sw.SwitchId = sw.Name = switchName;
                         sw.SwitchType = "External";
                         externalSwitches.Add(sw);
-                        HostedSolutionLog.LogWarning(string.Format("SwtichName {0}", switchName));
                     }
                 }
             }

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
@@ -2,6 +2,7 @@
 using Microsoft.Management.Infrastructure.Options;
 using Microsoft.Management.Infrastructure.Serialization;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -122,11 +123,11 @@ namespace SolidCP.Providers.Virtualization
         }
 
         /// <summary>
-        /// Get a CIM instance based on the provided light/proxy/empty instance object.
+        /// Get a CIM instance based on the provided light/proxy instance object.
         /// </summary>
-        public CimInstance GetInstance(CimInstance notInitInstance)
+        public CimInstance GetInstance(CimInstance proxyInstance)
         {
-            return _session.GetInstance(_namespacePath, notInitInstance);
+            return _session.GetInstance(_namespacePath, proxyInstance);
         }
 
         /// <summary>
@@ -246,6 +247,17 @@ namespace SolidCP.Providers.Virtualization
                     throw new ObjectDisposedException(ToString());
                 }
             }
+        }
+
+        internal void Dump(CimInstance obj)
+        {
+            #if DEBUG
+            foreach (var prop in obj.CimInstanceProperties)
+            {
+                string typeName = prop.Value == null ? "null" : prop.Value.GetType().ToString();
+                Debug.WriteLine(prop.Name + ": " + prop.Value + " (" + typeName + ")");
+            }
+            #endif
         }
 
         public void Dispose()

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Management.Infrastructure;
 using Microsoft.Management.Infrastructure.Options;
+using Microsoft.Management.Infrastructure.Serialization;
 using System;
 using System.Linq;
 using System.Text;
@@ -35,6 +36,13 @@ namespace SolidCP.Providers.Virtualization
             string target = string.IsNullOrWhiteSpace(targetComputer) ? null : targetComputer;
             _session = CimSession.Create(target, options);
             _namespacePath = namespacePath;
+        }
+
+        public string SerializeToCimDtd20(CimInstance cimInstance)
+        {
+            CimSerializer serializer = CimSerializer.Create();
+            byte[] serializedBytes = serializer.Serialize(cimInstance, InstanceSerializationOptions.None);
+            return Encoding.Unicode.GetString(serializedBytes);
         }
 
         public CimInstance GetCimInstance(string className)
@@ -98,6 +106,14 @@ namespace SolidCP.Providers.Virtualization
         public CimClass GetCimClass(string className)
         {
             return _session.GetClass(_namespacePath, className, null);
+        }
+
+        /// <summary>
+        /// Get a CIM instance based on the provided light/proxy/empty instance object.
+        /// </summary>
+        public CimInstance GetInstance(CimInstance notInitInstance)
+        {
+            return _session.GetInstance(_namespacePath, notInitInstance);
         }
 
         /// <summary>

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
@@ -54,9 +54,11 @@ namespace SolidCP.Providers.Virtualization
 
         public string SerializeToCimDtd20(CimInstance cimInstance)
         {
-            CimSerializer serializer = CimSerializer.Create();
-            byte[] serializedBytes = serializer.Serialize(cimInstance, InstanceSerializationOptions.None);
-            return Encoding.Unicode.GetString(serializedBytes);
+            using (CimSerializer serializer = CimSerializer.Create())
+            {
+                byte[] serializedBytes = serializer.Serialize(cimInstance, InstanceSerializationOptions.None);
+                return Encoding.Unicode.GetString(serializedBytes);
+            }            
         }
 
         public CimInstance GetCimInstance(string className)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/MiManager.cs
@@ -1,0 +1,213 @@
+﻿using Microsoft.Management.Infrastructure;
+using Microsoft.Management.Infrastructure.Options;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace SolidCP.Providers.Virtualization
+{
+    public class MiManager : IDisposable //MI/CIM is WMIv2 
+    {
+        private CimSession _session;
+        private readonly object _disposeThreadSafetyLock = new object();
+        private readonly string _namespacePath;
+
+        public bool IsDisposed { get; private set; } = false;
+
+        public MiManager(string targetComputer, CimSessionMode cimSessionMode, string namespacePath)
+        {
+            CimSessionOptions options;
+
+            switch (cimSessionMode)
+            {
+                case CimSessionMode.DCom:
+                    options = new DComSessionOptions(); // old (WMI)
+                    ((DComSessionOptions)options).Impersonation = ImpersonationType.Impersonate;
+                    break;
+                case CimSessionMode.WSMan:
+                    options = new WSManSessionOptions(); // new MI (CIM)
+                    break;
+                default:
+                    throw new ArgumentException("Invalid CIM session option.", nameof(cimSessionMode));
+            }
+            //CimCredential Credentials = new CimCredential(PasswordAuthenticationMechanism.Default, "domain", "username", "securepassword");
+            //options.AddDestinationCredentials(Credentials);
+            string target = string.IsNullOrWhiteSpace(targetComputer) ? null : targetComputer;
+            _session = CimSession.Create(target, options);
+            _namespacePath = namespacePath;
+        }
+
+        public CimInstance GetCimInstance(string className)
+        {
+            return EnumerateCimInstances(className).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// IMPORTANT! Use GetCimInstance without filter if possible (especially if it gets Accociations), as it is faster; 
+        /// otherwise, you will likely have to use GetCimInstanceWithSelect.
+        /// </summary>
+        public CimInstance GetCimInstance(string className, string filter, params object[] args)
+        {
+            return GetCimInstanceWithSelect(className, null, filter, args);
+        }
+
+        public CimInstance GetAssociatedCimInstance(CimInstance sourceInstance, string resultClassName)
+        {
+            return EnumerateAssociatedInstances(sourceInstance, null, resultClassName).FirstOrDefault();
+        }
+
+        public CimInstance GetAssociatedCimInstance(CimInstance sourceInstance, string resultClassName, string associationClassName)
+        {
+            return EnumerateAssociatedInstances(sourceInstance, associationClassName, resultClassName).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Retrieves a single instance of the specified CIM class using a WQL SELECT query.
+        /// IMPORTANT! To improve performance, avoid using arg select "*" or "null". Instead, specify only the required properties.
+        /// </summary>
+        public CimInstance GetCimInstanceWithSelect(string className, string select, string filter, params object[] args)
+        {
+            if (string.IsNullOrWhiteSpace(className)) {
+                throw new ArgumentException("Class name cannot be empty.", nameof(className));
+            }           
+
+            var queryBuilder = new StringBuilder();
+            queryBuilder.Append("SELECT")
+                        .Append(" ")
+                        .Append(string.IsNullOrWhiteSpace(select) ? "*" : select.Trim());
+
+            queryBuilder.Append(" ")
+                        .Append("FROM")
+                        .Append(" ")
+                        .Append(className.Trim());
+
+            if (!string.IsNullOrWhiteSpace(filter)) {
+                queryBuilder.Append(" ")
+                            .Append("WHERE")
+                            .Append(" ")
+                            .Append(filter.Trim());
+            }
+
+            string query = queryBuilder.ToString();
+            if (args != null && args.Length > 0) {
+                query = string.Format(query, args);
+            }
+            return QueryCimInstances(query).FirstOrDefault();
+        }
+
+        public CimClass GetCimClass(string className)
+        {
+            return _session.GetClass(_namespacePath, className, null);
+        }
+
+        /// <summary>
+        /// Queries instances of the specified CIM class.
+        /// </summary>
+        public CimInstance[] EnumerateCimInstances(string className)
+        {
+            AssertNotDisposed();
+            if (string.IsNullOrWhiteSpace(className)){
+                throw new ArgumentException("Class name cannot be empty.", nameof(className));
+            }
+
+            return _session.EnumerateInstances(_namespacePath, className).ToArray();
+        }
+
+        /// <summary>
+        /// IMPORTANT! Use EnumerateCimInstances if possible, as it is faster; otherwise, you will likely have to use SELECT.
+        /// Queries instances of the specified CIM class.
+        /// WQL - https://learn.microsoft.com/en-us/windows/win32/wmisdk/wql-sql-for-wmi.
+        /// </summary>
+        public CimInstance[] QueryCimInstances(string query)
+        {
+            AssertNotDisposed();
+            if (string.IsNullOrWhiteSpace(query)){
+                throw new ArgumentException("Query cannot be empty.", nameof(query));
+            }
+            return _session.QueryInstances(_namespacePath, "WQL", query).ToArray();
+        }
+
+        /// <summary>
+        /// Retrieves an array of CIM instances that are associated with the specified source instance using the given association parameters.
+        /// </summary>
+        /// <param name="sourceInstance">The source instance from which to retrieve associated instances.</param>
+        /// <param name="associationClassName">
+        /// =============================
+        /// IMPORTANT! If the association class is not specified, performance WILL BE significantly reduced.
+        /// =============================
+        /// The name of the association class that defines the relationship between the source and target objects. 
+        /// Use null if no specific association class filter is needed.
+        /// </param>
+        /// <param name="resultClassName">
+        /// The name of the target (result) class. Use null if no specific result class filter is needed.
+        /// </param>
+        /// <param name="sourceRole">
+        /// Optional. The role of the source instance in the association. Pass null if not required.
+        /// </param>
+        /// <param name="resultRole">
+        /// Optional. The role of the target instance in the association. Pass null if not required.
+        /// </param>
+        /// <returns>
+        /// An array of CIM instances that are associated with the given source instance according to the specified parameters.
+        /// </returns>
+        public CimInstance[] EnumerateAssociatedInstances(
+            CimInstance sourceInstance, 
+            string associationClassName, 
+            string resultClassName, 
+            string sourceRole = null, 
+            string resultRole = null
+            )
+        {
+            AssertNotDisposed();
+
+            return _session.EnumerateAssociatedInstances(
+                _namespacePath, 
+                sourceInstance, 
+                associationClassName,
+                resultClassName,
+                sourceRole,
+                resultRole
+                ).ToArray();
+        }
+
+        /// <summary>
+        /// Invokes the specified method on a given CIM instance.
+        /// </summary>
+        /// <param name="instance">The CIM instance.</param>
+        /// <param name="methodName">The method name to invoke.</param>
+        /// <param name="parameters">Optional method parameters.</param>
+        /// <returns>The result of the method invocation.</returns>
+        public CimMethodResult InvokeMethod(CimInstance instance, string methodName, CimMethodParametersCollection parameters = null)
+        {
+            AssertNotDisposed();
+
+            if (instance == null)
+                throw new ArgumentNullException(nameof(instance));
+            if (string.IsNullOrWhiteSpace(methodName))
+                throw new ArgumentException("Method name cannot be empty.", nameof(methodName));
+
+            return _session.InvokeMethod(instance, methodName, parameters);
+        }
+
+        internal void AssertNotDisposed()
+        {
+            lock (_disposeThreadSafetyLock)
+            {
+                if (IsDisposed)
+                {
+                    throw new ObjectDisposedException(ToString());
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!IsDisposed)
+            {
+                _session?.Dispose();
+                _session = null;
+                IsDisposed = true;
+            }
+        }        
+    }
+}

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/PowerShellManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/PowerShellManager.cs
@@ -16,6 +16,7 @@ namespace SolidCP.Providers.Virtualization
         object psLocker = new object();
         private bool isStatic = false;
         public bool IsStaticObj { get => isStatic; }
+        public string RemoteComputerName { get => _remoteComputerName; }
 
         protected Runspace RunSpace { get; set; }
 

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/PowerShellManager.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/PowerShellManager.cs
@@ -71,9 +71,21 @@ namespace SolidCP.Providers.Virtualization
             }
         }
 
-        public Collection<PSObject> Execute(Command cmd)
+        /// <summary>
+        /// Executes the specified PowerShell command against the provided virtual machine by automatically
+        /// adding the "-VM" parameter.
+        /// </summary>
+        /// <remarks>
+        /// Not all PowerShell cmdlets support the "-VM" parameter; please consult the official documentation
+        /// for each cmdlet to verify compatibility before using this method.
+        /// </remarks>
+        public Collection<PSObject> ExecuteOnVm(Command cmd, VirtualMachineData vmData, bool withExceptions = false)
         {
-            return Execute(cmd, true);
+            if (vmData.RawObject == null)
+                throw new NullReferenceException("VM rawObject is null! You must use GetVirtualMachine/GetVmPSObject method before using this method!");
+
+            cmd.Parameters.Add("VM", vmData.RawObject);
+            return Execute(cmd, false, withExceptions); //False, because all remote connection information is already contained in RawObject
         }
 
         public Collection<PSObject> Execute(Command cmd, bool addComputerNameParameter)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
@@ -35,6 +35,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Management.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Storage.Vds">
       <HintPath>..\..\Lib\References\Microsoft\Microsoft.Storage.Vds.dll</HintPath>
     </Reference>
@@ -55,6 +56,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="MiManager.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Extensions\PSObjectExtension.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Helpers\FileSystemHelper.cs" />
     <Compile Include="MiManager.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Extensions\PSObjectExtension.cs" />

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/SolidCP.Providers.Virtualization.HyperV2012R2.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Data\VirtualMachineData.cs" />
     <Compile Include="Helpers\FileSystemHelper.cs" />
     <Compile Include="MiManager.cs" />
     <Compile Include="Constants.cs" />

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Wmi.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Wmi.cs
@@ -38,6 +38,10 @@ using System.Diagnostics;
 
 namespace SolidCP.Providers.Virtualization
 {
+    /// <summary>
+    /// DEPRECATED: This class will be removed in the next release (after 2025?).
+    /// Please use <c>MiManager</c> instead.
+    /// </summary>
     internal class Wmi
     {
         string nameSpace = null;

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Wmi.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Wmi.cs
@@ -103,8 +103,7 @@ namespace SolidCP.Providers.Virtualization
         {
             ManagementObjectCollection col = obj.GetRelated(className);
             ManagementObjectCollection.ManagementObjectEnumerator enumerator = col.GetEnumerator();
-            enumerator.MoveNext();
-            return (ManagementObject)enumerator.Current;
+            return enumerator.MoveNext() ? (ManagementObject)enumerator.Current : null;
         }
 
         internal void Dump(ManagementBaseObject obj)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2019/SolidCP.Providers.Virtualization.HyperV2019.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2019/SolidCP.Providers.Virtualization.HyperV2019.csproj
@@ -39,11 +39,6 @@
       <HintPath>..\..\Lib\References\Microsoft\Microsoft.Storage.Vds.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SolidCP.Providers.Virtualization.HyperV2012R2, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SolidCP.Server\bin\HyperV2012R2\SolidCP.Providers.Virtualization.HyperV2012R2.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -77,6 +72,10 @@
       <Project>{a06de5e4-4331-47e1-8f46-7b846146b559}</Project>
       <Name>SolidCP.Providers.HostedSolution</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\SolidCP.Providers.Virtualization.HyperV-2012R2\SolidCP.Providers.Virtualization.HyperV2012R2.csproj">
+      <Project>{ee40516b-93df-4cab-80c4-64dce0b751cc}</Project>
+      <Name>SolidCP.Providers.Virtualization.HyperV2012R2</Name>
     </ProjectReference>
     <ProjectReference Include="..\SolidCP.Server.Utils\SolidCP.Server.Utils.csproj">
       <Project>{e91e52f3-9555-4d00-b577-2b1dbdd87ca7}</Project>

--- a/SolidCP/Sources/SolidCP.Server/VirtualizationServer2012.asmx.cs
+++ b/SolidCP/Sources/SolidCP.Server/VirtualizationServer2012.asmx.cs
@@ -482,7 +482,7 @@ namespace SolidCP.Server
             try
             {
                 Log.WriteStart("'{0}' GetExternalSwitchesWMI", ProviderSettings.ProviderName);
-                List<VirtualSwitch> result = VirtualizationProvider.GetExternalSwitches(computerName);
+                List<VirtualSwitch> result = VirtualizationProvider.GetExternalSwitchesWMI(computerName);
                 Log.WriteEnd("'{0}' GetExternalSwitchesWMI", ProviderSettings.ProviderName);
                 return result;
             }

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx
@@ -30,6 +30,14 @@
                     Text="*" meta:resourcekey="ServerNameValidator" Display="Dynamic" SetFocusOnError="true" />
             </td>
 	    </tr>
+        <tr id="ServerCimSessionModeRow" runat="server">
+            <td colspan="2">
+                <asp:RadioButtonList ID="radioCimSessionMode" runat="server">
+                    <asp:ListItem Value="0" meta:resourcekey="radioCimSessionModeDCom" Selected="True">DCom</asp:ListItem>
+                    <asp:ListItem Value="1" meta:resourcekey="radioCimSessionModeWSMan">WSMan (experemental)</asp:ListItem>
+                </asp:RadioButtonList>
+            </td>
+        </tr>
 	    <tr id="ServerErrorRow" runat="server">
 	        <td colspan="2">
 	            <asp:Label ID="locErrorReadingNetworksList" runat="server"

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx.cs
@@ -63,7 +63,10 @@ namespace SolidCP.Portal.ProviderControls
         {
             txtServerName.Text = settings["ServerName"];
             radioServer.SelectedIndex = (txtServerName.Text == "") ? 0 : 1;
-            
+            radioCimSessionMode.SelectedValue = settings["CimSessionMode"];
+            radioCimSessionMode.SelectedIndex = string.IsNullOrEmpty(radioCimSessionMode.SelectedValue)
+                ? 0 : radioCimSessionMode.SelectedIndex;
+
             // bind networks
             BindNetworksList();
 
@@ -205,10 +208,14 @@ namespace SolidCP.Portal.ProviderControls
 
         void IHostingServiceProviderSettings.SaveSettings(StringDictionary settings)
         {            
-            if (radioServer.SelectedIndex == 0)
+            if (radioServer.SelectedIndex == 0){
                 settings["ServerName"] = "";
-            else
+                settings["CimSessionMode"] = "0";
+            }
+            else{
                 settings["ServerName"] = txtServerName.Text.Trim();
+                settings["CimSessionMode"] = radioCimSessionMode.SelectedValue;
+            }
 
             // MaintenanceMode
             settings["MaintenanceMode"] = radioMaintenanceMode.SelectedValue;
@@ -450,11 +457,13 @@ namespace SolidCP.Portal.ProviderControls
         private void ToggleControls()
         {
             ServerNameRow.Visible = (radioServer.SelectedIndex == 1);
+            ServerCimSessionModeRow.Visible = (radioServer.SelectedIndex == 1);
 
             txtRamReserve.Enabled = true;
             if (radioServer.SelectedIndex == 0)
             {
-                txtServerName.Text = "";                
+                txtServerName.Text = "";         
+                radioCimSessionMode.SelectedIndex = 0;
             }
             else
             {

--- a/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx.designer.cs
+++ b/SolidCP/Sources/SolidCP.WebPortal/DesktopModules/SolidCP/ProviderControls/HyperV2012R2_Settings.ascx.designer.cs
@@ -96,6 +96,24 @@ namespace SolidCP.Portal.ProviderControls
         protected global::System.Web.UI.WebControls.RequiredFieldValidator ServerNameValidator;
 
         /// <summary>
+        /// ServerCimSessionModeRow control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlTableRow ServerCimSessionModeRow;
+
+        /// <summary>
+        /// radioCimSessionMode control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RadioButtonList radioCimSessionMode;
+
+        /// <summary>
         /// ServerErrorRow control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
# Description

This PR is related to issue #224 and aims to optimize Hyper-V performance on high-load nodes. On average, performance will improve by about 2x, and in some cases, up to 6x. On nodes with fewer than 100 servers, there may be no noticeable changes, except for a more responsive control panel when working with VMs.

### **1.** A modern tool, MI/CIM, has been added:
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmi_v2/windows-management-infrastructure

Unlike WMI, MI/CIM supports not only DCom but also the modern DSMan:
https://support.quest.com/kb/4311903/comparison-between-dcom-wmi-and-winrm-technologies

By default, MI uses DCom for Remote Hyper-V. This can be changed in the Provider Settings.
![0MiSetting](https://github.com/user-attachments/assets/46ca23c6-4afe-41bd-9e61-99ababbce263)

### **2.** Multi-command support for PowerShell has been added, allowing multiple commands to run without switching to script mode.
Example PowerShell:
```powershell
Get-VM -Id 'VM_ID' | Select-Object -Property Id, Name, State
```
C#
```csharp
var commands = new List<Command>
{
    new Command("Get-VM")
    {
        Parameters = { { "Id", vmId } }
    },
    new Command("Select-Object") { 
        Parameters = {
            {
                "Property", new string[] { 
                    "Id", 
                    "Name",
                    "State",
                }
            }
        }
    }
};
```

### **3.** Some methods have been partially optimized.
For example, retrieving all virtual machines **(tested with 400 VMs)**:
Pure Powershell:
```powershell
Measure-Command {
Get-VM 
}

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 26
Milliseconds      : 719
Ticks             : 267193560
TotalDays         : 0.000309251805555556
TotalHours        : 0.00742204333333333
TotalMinutes      : 0.4453226
TotalSeconds      : 26.719356
TotalMilliseconds : 26719.356
```
WMIv2 imitation (around x20 times faster):
```powershell
Measure-Command {
Get-CimInstance -Namespace "root\virtualization\v2" -ClassName Msvm_ComputerSystem
}

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 393
Ticks             : 13939983
TotalDays         : 1.61342395833333E-05
TotalHours        : 0.00038722175
TotalMinutes      : 0.023233305
TotalSeconds      : 1.3939983
TotalMilliseconds : 1393.9983
```
Retrieving data for a single server (testing on a high-load node):
```powershell
Measure-Command {
Get-VM -Name "VM_NAME"
}

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 695
Ticks             : 16958672
TotalDays         : 1.96280925925926E-05
TotalHours        : 0.000471074222222222
TotalMinutes      : 0.0282644533333333
TotalSeconds      : 1.6958672
TotalMilliseconds : 1695.8672
```
WMIv2 (around x2 time faster)
```powershell
Measure-Command {
Get-CimInstance -Namespace "root\virtualization\v2" -ClassName Msvm_ComputerSystem -Filter "ElementName='VM_NAME'"
}

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 683
Ticks             : 6835916
TotalDays         : 7.91193981481481E-06
TotalHours        : 0.000189886555555556
TotalMinutes      : 0.0113931933333333
TotalSeconds      : 0.6835916
TotalMilliseconds : 683.5916
```
**IMPORTANT**: When testing, you must start a new PowerShell session each time (open a new PowerShell ISE). Otherwise, after the first run, data will be cached in the current session. Since SolidCP creates a new session for each request, it cannot use cached PowerShell queries. As seen in the results, the first run is so slow in PowerShell that it negates its advantages.

These data simply show how poorly PowerShell performs in some cases. However, I don’t plan to replace everything with WMI because, as always, Microsoft can’t decide which tool should replace another. As a result, PowerShell sometimes has access to data that WMI doesn’t - and vice versa. 🙂
In this PR, I only plan to replace/rewrite the most problematic areas.