### PR TITLE
[HyperV] Check and update the VM RootFolderPath and VirtualHardDrivePath in the database

### DIFF
--- a/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VirtualMachineHelper.cs
+++ b/SolidCP/Sources/SolidCP.EnterpriseServer.Code/Virtualization2012/Helpers/VirtualMachineHelper.cs
@@ -80,6 +80,9 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers
             // load details
             VirtualMachine vm = vps.GetVirtualMachine(machine.VirtualMachineId);
 
+            // check if VM RootFolderPath and VirtualHardDrivePath is correct
+            CheckVirtualMachinePath(machine, vm, vps);
+
             // add meta props
             vm.Id = machine.Id;
             vm.Name = machine.Name;
@@ -89,6 +92,32 @@ namespace SolidCP.EnterpriseServer.Code.Virtualization2012.Helpers
             vm.ExternalNicMacAddress = machine.ExternalNicMacAddress;
 
             return vm;
+        }
+
+        private static void CheckVirtualMachinePath(VirtualMachine vmItem, VirtualMachine realVm, VirtualizationServer2012 vps)
+        {
+            bool update = false;
+            if (!String.IsNullOrEmpty(realVm.RootFolderPath) && !realVm.RootFolderPath.Equals(vmItem.RootFolderPath))
+            {
+                vmItem.RootFolderPath = realVm.RootFolderPath;
+                update = true;
+            }
+            if (realVm.VirtualHardDrivePath != null && realVm.VirtualHardDrivePath.Length > 0)
+            {
+                if (!realVm.VirtualHardDrivePath.SequenceEqual(vmItem.VirtualHardDrivePath))
+                {
+                    // we also need to update the HddSize array to match the paths
+                    VirtualMachine extVm = vps.GetVirtualMachineEx(vmItem.VirtualMachineId);
+                    if (extVm.VirtualHardDrivePath != null && extVm.VirtualHardDrivePath.Length > 0 
+                        && extVm.HddSize != null && extVm.VirtualHardDrivePath.Length == extVm.HddSize.Length)
+                    {
+                        vmItem.VirtualHardDrivePath = extVm.VirtualHardDrivePath;
+                        vmItem.HddSize = extVm.HddSize;
+                        update = true;
+                    }
+                }
+            }
+            if (update) PackageController.UpdatePackageItem(vmItem);
         }
 
         public static VirtualMachine GetVirtualMachineExtendedInfo(int serviceId, string vmId)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/HardDriveHelper.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/Helpers/HardDriveHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Management.Infrastructure;
 using SolidCP.Providers.Utils;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -77,6 +78,17 @@ namespace SolidCP.Providers.Virtualization
             Command cmd = new Command("Get-VMHardDiskDrive");
 
             return _powerShell.ExecuteOnVm(cmd, vmData, withExceptions);
+        }
+
+        public string[] GetVirtualHardDiskPathFromVmPsObject(PSObject vmObject)
+        {
+            List<string> pathes = new List<string>();
+            foreach (var hardDrive in (IEnumerable)vmObject.GetProperty("HardDrives"))
+            {
+                string path = (string)hardDrive.GetType().GetProperty("Path").GetValue(hardDrive);
+                if (!String.IsNullOrEmpty(path)) pathes.Add(path);
+            }
+            return pathes.ToArray();
         }
 
         public void GetVirtualHardDiskDetail(string path, ref VirtualHardDiskInfo disk)

--- a/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Virtualization.HyperV-2012R2/HyperV2012R2.cs
@@ -274,7 +274,9 @@ namespace SolidCP.Providers.Virtualization
                     vm.CreatedDate = vmObject.GetProperty<DateTime>("CreationTime");
                     vm.ReplicationState = vmObject.GetEnum<ReplicationState>("ReplicationState", ReplicationState.NotApplicable, suppressErrors);
                     vm.IsClustered = vmObject.GetBool("IsClustered");
+                    vm.RootFolderPath = vmObject.GetString("Path");
 
+                    vm.VirtualHardDrivePath = HardDriveHelper.GetVirtualHardDiskPathFromVmPsObject(vmObject);
                     vm.DynamicMemory = MemoryHelper.GetDynamicMemory(vmData);
                 }
             }


### PR DESCRIPTION
# Description

If VM or VHDX path was changed on the HyperV, then the data in the database remains inconsistent. This PR checks and updates the data when the VM is opened in SolidCP. Even if a VHDX was added directly in HyperV, it will be automatically assigned in SolidCP later.
The PR should not affect performance if the data is already up to date.