### PR TITLE
Fixed build error & Removed net48 references in SmarterMail100

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To download the latest Binaries or find more information visit our website at:
 
 Here are some [tutorials for SolidCP](https://www.youtube.com/playlist?list=PLViYFEOr_vWBMyf_Co7RXs9rDQQK4y5pj).
 
-Here's a [programmer's introduction video to the SolidCP Linux port](https://youtu.be/RBxv2wvfMdw). 
+Here's a [programmer's introduction video to the SolidCP Linux port](https://youtu.be/RBxv2wvfMdw).

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To download the latest Binaries or find more information visit our website at:
 
 Here are some [tutorials for SolidCP](https://www.youtube.com/playlist?list=PLViYFEOr_vWBMyf_Co7RXs9rDQQK4y5pj).
 
-Here's a [programmer's introduction video to the SolidCP Linux port](https://youtu.be/RBxv2wvfMdw).
+Here's a [programmer's introduction video to the SolidCP Linux port](https://youtu.be/RBxv2wvfMdw). 

--- a/SolidCP/Sources/SolidCP.Providers.Mail.SmarterMail100/SolidCP.Providers.Mail.SmarterMail100.csproj
+++ b/SolidCP/Sources/SolidCP.Providers.Mail.SmarterMail100/SolidCP.Providers.Mail.SmarterMail100.csproj
@@ -23,10 +23,6 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>
-		<Reference Include="System.Net.Http" />
-		<Reference Include="System.Web.Services" />
-	</ItemGroup>
-	<ItemGroup>
 		<Compile Include="..\VersionInfo.cs" Link="VersionInfo.cs" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
- Fixed build error
- Removed .NET Framework References in SmarterMail100.csproj
- SmarterMail100 should now run on Linux too