### PR TITLE
[MariaDB] calculate database size fixed

### DIFF
--- a/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB101.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB101.cs
@@ -241,7 +241,7 @@ namespace SolidCP.Providers.Database
             }
 
             //size in KB
-            database.DataSize = (int)(data + index) / 1024;
+            database.DataSize = (int)((data + index) / 1024);
 
             // get database uzers
             database.Users = GetDatabaseUsers(databaseName);

--- a/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB103.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB103.cs
@@ -64,11 +64,13 @@ namespace SolidCP.Providers.Database
 
         public override long CalculateDatabaseSize(string database)
         {
-            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) / 1024 AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
-            List<string> dbsize = new List<string>();
-            foreach (DataRow dr in dt.Rows)
-                dbsize.Add(dr["Size"].ToString());
-            return Convert.ToInt64(dbsize.ToString());
+            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
+            string dbsize = dt.Rows[0]["Size"].ToString();
+            if (String.IsNullOrEmpty(dbsize)) // empty database
+            {
+                dbsize = "0";
+            }
+            return Convert.ToInt64(dbsize);
         }
 
         #region private helper methods

--- a/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB104.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB104.cs
@@ -64,11 +64,13 @@ namespace SolidCP.Providers.Database
 
         public override long CalculateDatabaseSize(string database)
         {
-            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) / 1024 AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
-            List<string> dbsize = new List<string>();
-            foreach (DataRow dr in dt.Rows)
-                dbsize.Add(dr["Size"].ToString());
-            return Convert.ToInt64(dbsize.ToString());
+            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
+            string dbsize = dt.Rows[0]["Size"].ToString();
+            if (String.IsNullOrEmpty(dbsize)) // empty database
+            {
+                dbsize = "0";
+            }
+            return Convert.ToInt64(dbsize);
         }
 
         #region private helper methods

--- a/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB105.cs
+++ b/SolidCP/Sources/SolidCP.Providers.Database.MariaDB/MariaDB105.cs
@@ -64,11 +64,13 @@ namespace SolidCP.Providers.Database
 
         public override long CalculateDatabaseSize(string database)
         {
-            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) / 1024 AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
-            List<string> dbsize = new List<string>();
-            foreach (DataRow dr in dt.Rows)
-                dbsize.Add(dr["Size"].ToString());
-            return Convert.ToInt64(dbsize.ToString());
+            DataTable dt = ExecuteQuery(string.Format("SELECT SUM(data_length + index_length) AS 'Size' FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{0}'", database));
+            string dbsize = dt.Rows[0]["Size"].ToString();
+            if (String.IsNullOrEmpty(dbsize)) // empty database
+            {
+                dbsize = "0";
+            }
+            return Convert.ToInt64(dbsize);
         }
 
         #region private helper methods


### PR DESCRIPTION
# Description

- [MariaDB] calculate database size fixed

Fixes # (issue)

MariaDB displayed false database size
Errors in EventLog fixed: "Error calculating MariaDB database size - System.FormatException: Input string was not in a correct format."